### PR TITLE
Ensure no negative positions when compacting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -257,6 +257,11 @@ export function compactItem(
       l.y++;
     }
   }
+  
+  // Ensure that there are no negative positions
+  l.y = Math.max(l.y, 0);
+  l.x = Math.max(l.x, 0);
+  
   return l;
 }
 


### PR DESCRIPTION
Ensure no negative positions in util.js compactItem function.

Fixes #535.
