### PR TITLE
Resize placeholder should not capture pointer events

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -34,6 +34,7 @@
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
+  pointer-events: none;
 }
 
 .react-grid-item > .react-resizable-handle {


### PR DESCRIPTION
# Why

Currently the resizing placeholder captures pointer events, e.g. while resizing the
cursor bounces back and forth between the placeholder and the actually
resized item.

This in turn can result into undesired side-effects/flickering when users modify
the resizing edge via CSS, e.g. when adding a hover effect to the resizing
edge.

# What

Disable pointer events. This way the placeholder never captures the pointer
events (neither for JS nor CSS).
