### PR TITLE
Adds drag API

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -35,7 +35,8 @@ import type {
   DragOverEvent,
   Layout,
   DroppingPosition,
-  LayoutItem
+  LayoutItem,
+  DragApiRefObject
 } from "./utils";
 
 import type { PositionParams } from "./calculateUtils";
@@ -99,6 +100,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     verticalCompact: true,
     compactType: "vertical",
     preventCollision: false,
+    dragApiRef: React.createRef<DragApiRefObject>(),
     droppingItem: {
       i: "__dropping-elem__",
       h: 1,
@@ -146,6 +148,89 @@ export default class ReactGridLayout extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    let dragInfo = null;
+
+    this.props.dragApiRef.current = {
+      dragIn: ({ layoutItem, node, event, position }) => {
+        dragInfo = { layoutItem, node };
+        const { w, h } = layoutItem;
+        const { layout } = this.state;
+        const { margin, containerPadding } = this.props;
+        const { x, y } = calcXY(
+          {
+            containerWidth: this.props.width,
+            cols: this.props.cols,
+            margin,
+            containerPadding: containerPadding || margin,
+            rowHeight: this.props.rowHeight,
+            maxRows: this.props.maxRows
+          },
+          position.top,
+          position.left,
+          w,
+          h
+        );
+        if (!this.state.activeDrag) {
+          const l = { ...layoutItem, x, y };
+          this.setState({
+            oldDragItem: l,
+            oldLayout: layout,
+            layout: [...this.state.layout, l],
+            activeDrag: l
+          });
+          this.props.onDragStart(layout, l, l, null, event, node);
+        } else {
+          this.onDrag(layoutItem.i, x, y, {
+            e: event,
+            node,
+            newPosition: position
+          });
+        }
+      },
+
+      dragOut: () => {
+        if (dragInfo) {
+          const { layoutItem } = dragInfo;
+          this.setState((state, props) => ({
+            layout: compact(
+              state.layout.filter(d => d.i !== layoutItem.i),
+              compactType(this.props),
+              props.cols
+            ),
+            activeDrag: null
+          }));
+        }
+      },
+
+      stop: ({ event, position }) => {
+        if (dragInfo) {
+          const { layoutItem, node } = dragInfo;
+          const { w, h } = layoutItem;
+          const { margin, containerPadding } = this.props;
+          const { x, y } = calcXY(
+            {
+              containerWidth: this.props.width,
+              cols: this.props.cols,
+              margin,
+              containerPadding: containerPadding || margin,
+              rowHeight: this.props.rowHeight,
+              maxRows: this.props.maxRows
+            },
+            position.top,
+            position.left,
+            w,
+            h
+          );
+          this.onDragStop(layoutItem.i, x, y, {
+            e: event,
+            node,
+            newPosition: position
+          });
+          dragInfo = null;
+        }
+      }
+    };
+
     this.setState({ mounted: true });
     // Possibly call back with layout on mount. This should be done after correcting the layout width
     // to ensure we don't rerender with the wrong width.

--- a/lib/ReactGridLayoutPropTypes.js
+++ b/lib/ReactGridLayoutPropTypes.js
@@ -6,7 +6,13 @@ import type {
   ChildrenArray as ReactChildrenArray,
   Element as ReactElement
 } from "react";
-import type { EventCallback, CompactType, Layout, LayoutItem } from "./utils";
+import type {
+  EventCallback,
+  CompactType,
+  Layout,
+  LayoutItem,
+  DragApiRefObject
+} from "./utils";
 
 export type Props = {|
   className: string,
@@ -30,7 +36,7 @@ export type Props = {|
   useCSSTransforms: boolean,
   transformScale: number,
   droppingItem: $Shape<LayoutItem>,
-
+  dragApiRef: DragApiRefObject,
   // Callbacks
   onLayoutChange: Layout => void,
   onDrag: EventCallback,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+export * from "./calculateUtils";
 // @flow
 import isEqual from "lodash.isequal";
 import React from "react";
@@ -69,6 +70,21 @@ export type EventCallback = (
   ?HTMLElement
 ) => void;
 export type CompactType = ?("horizontal" | "vertical");
+
+type DragApi = {
+  dragIn({
+    layoutItem: LayoutItem,
+    position: PartialPosition,
+    event: MouseEvent,
+    node: HTMLElement
+  }): void,
+  dragOut({ position: PartialPosition, event: MouseEvent }): void,
+  stop({ position: PartialPosition, event: MouseEvent }): void
+};
+
+export type DragApiRefObject = {
+  current: ?DragApi
+};
 
 const isProduction = process.env.NODE_ENV === "production";
 const DEBUG = false;

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -166,6 +166,15 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
       cols={12}
       compactType="vertical"
       containerPadding={null}
+      dragApiRef={
+        Object {
+          "current": Object {
+            "dragIn": [Function],
+            "dragOut": [Function],
+            "stop": [Function],
+          },
+        }
+      }
       draggableCancel=""
       draggableHandle=""
       droppingItem={
@@ -4184,6 +4193,15 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               0,
               0,
             ]
+          }
+          dragApiRef={
+            Object {
+              "current": Object {
+                "dragIn": [Function],
+                "dragOut": [Function],
+                "stop": [Function],
+              },
+            }
           }
           draggableCancel=""
           draggableHandle=""


### PR DESCRIPTION
This adds a drag API to react-grid-layout.
It is an update on another PR https://github.com/STRML/react-grid-layout/pull/684.

I need to add tests and would love some suggestions.