### PR TITLE
fix `onResizeStop` not firing `onLayoutChange`

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -15,7 +15,8 @@ import {
   getAllCollisions,
   compactType,
   noop,
-  fastRGLPropsEqual
+  fastRGLPropsEqual,
+  cloneLayout
 } from "./utils";
 
 import { calcXY } from "./calculateUtils";
@@ -371,7 +372,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
   }
 
   onResize(i: string, w: number, h: number, { e, node }: GridResizeEvent) {
-    const { layout, oldResizeItem } = this.state;
+    const { oldResizeItem } = this.state;
+    const layout = cloneLayout(this.state.layout);
     const { cols, preventCollision } = this.props;
     const l: ?LayoutItem = getLayoutItem(layout, i);
     if (!l) return;


### PR DESCRIPTION
Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.

ref issue: https://github.com/STRML/react-grid-layout/issues/593