### PR TITLE
CalcXY uses Math.floor instead of Math.round so item doesn't pop to n…

### DIFF
--- a/lib/calculateUtils.js
+++ b/lib/calculateUtils.js
@@ -107,8 +107,8 @@ export function calcXY(
   // l - m = x(c + m)
   // (l - m) / (c + m) = x
   // x = (left - margin) / (coldWidth + margin)
-  let x = Math.round((left - margin[0]) / (colWidth + margin[0]));
-  let y = Math.round((top - margin[1]) / (rowHeight + margin[1]));
+  let x = Math.floor((left - margin[0]) / (colWidth + margin[0]));
+  let y = Math.floor((top - margin[1]) / (rowHeight + margin[1]));
 
   // Capping
   x = clamp(x, 0, cols - w);

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -81,7 +81,7 @@ describe("Lifecycle tests", function () {
           h: 1,
           w: 1,
           x: 1,
-          y: 4,
+          y: 3,
           static: false,
           isDraggable: true
         });


### PR DESCRIPTION
[Related issue](https://github.com/STRML/react-grid-layout/issues/1352)

By replacing Math.round with Math.floor the droppingItem exhibits more natural behaviour when dragging into columns
