### PR TITLE
Fix position bug (drag in scaled mode)

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -447,10 +447,8 @@ export default class GridItem extends React.Component<Props, State> {
    * @param  {Object} callbackData  an object with node, delta and position information
    */
   onDrag = (e: Event, { node, deltaX, deltaY }: ReactDraggableCallbackData) => {
-    const { onDrag, transformScale } = this.props;
+    const { onDrag } = this.props;
     if (!onDrag) return;
-    deltaX /= transformScale;
-    deltaY /= transformScale;
 
     if (!this.state.dragging) {
       throw new Error("onDrag called before onDragStart.");


### PR DESCRIPTION
We have position bug when dragging GridItem in scaled mode. 

[CodeSandbox example](https://codesandbox.io/s/eager-leaf-kmedd)

This is old bug, and its have been already fixed. But its looks like it have been fixed twice, first in the react-grid-layout and second in react-draggable (may be in react-scalable too). As a result, we again have a positioning error.