### PR TITLE
fix: flow type check error (DragOverEvent)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ export type LayoutItem = {
   static?: boolean,
   isDraggable?: ?boolean,
   isResizable?: ?boolean,
-  resizeHandles?: Array<'s' | 'w' | 'e' | 'n' | 'sw' | 'nw' | 'se' | 'ne'>,
+  resizeHandles?: Array<"s" | "w" | "e" | "n" | "sw" | "nw" | "se" | "ne">,
   isBounded?: ?boolean
 };
 export type Layout = $ReadOnlyArray<LayoutItem>;
@@ -53,7 +53,8 @@ export type DragOverEvent = MouseEvent & {
     layerX: number,
     layerY: number,
     target: {
-      className: String
+      className: String,
+      classList: DOMTokenList
     }
   }
 };


### PR DESCRIPTION
Correct `classList` type from console

![image](https://user-images.githubusercontent.com/12877711/103516659-dbdd0000-4eab-11eb-9dfd-2274871fc90b.png)
