### PR TITLE
new link added to the 'Projects Using' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ RGL is React-only and does not require jQuery.
 - [Quadency](https://quadency.com/)
 - [Hakkiri](https://www.hakkiri.io)
 - [Ubidots](https://help.ubidots.com/en/articles/2400308-create-dashboards-and-widgets)
+- [Statsout](https://statsout.com/)
 
 *Know of others? Create a PR to let me know!*
 


### PR DESCRIPTION
I'd like to submit my own micro SaaS that I build using React Grid Layout to the "Projects Using..." list in README.

It's a dashboard app so RGL is at the core of everything and serves as a good example.

Thanks for this repo by the way. Fantastic work.