### PR TITLE
Horizontal Compact Mode issues

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -79,14 +79,23 @@ const DEBUG = false;
  * Return the bottom coordinate of the layout.
  *
  * @param  {Array} layout Layout array.
+ * @param  {CompactType} compactType to identify the orientation for the
  * @return {Number}       Bottom coordinate.
  */
-export function bottom(layout: Layout): number {
+export function bottom(layout: Layout, compactType: CompactType): number {
+  const compactH = compactType === "horizontal";
   let max = 0,
-    bottomY;
+    bottomPos;
+
+  // we need some default, so take vertical?
+  let getBottomPos = item => item.y + item.h;
+  if (compactH) {
+    getBottomPos = item => item.x + item.w;
+  }
+
   for (let i = 0, len = layout.length; i < len; i++) {
-    bottomY = layout[i].y + layout[i].h;
-    if (bottomY > max) max = bottomY;
+    bottomPos = getBottomPos(layout[i]);
+    if (bottomPos > max) max = bottomPos;
   }
   return max;
 }
@@ -270,13 +279,13 @@ export function compactItem(
     // Bottom 'y' possible is the bottom of the layout.
     // This allows you to do nice stuff like specify {y: Infinity}
     // This is here because the layout must be sorted in order to get the correct bottom `y`.
-    l.y = Math.min(bottom(compareWith), l.y);
+    l.y = Math.min(bottom(compareWith, compactType), l.y);
     // Move the element up as far as it can go without colliding.
     while (l.y > 0 && !getFirstCollision(compareWith, l)) {
       l.y--;
     }
   } else if (compactH) {
-    l.y = Math.min(bottom(compareWith), l.y);
+    l.x = Math.min(bottom(compareWith, compactType), l.x);
     // Move the element left as far as it can go without colliding.
     while (l.x > 0 && !getFirstCollision(compareWith, l)) {
       l.x--;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -79,23 +79,14 @@ const DEBUG = false;
  * Return the bottom coordinate of the layout.
  *
  * @param  {Array} layout Layout array.
- * @param  {CompactType} compactType to identify the orientation for the
  * @return {Number}       Bottom coordinate.
  */
-export function bottom(layout: Layout, compactType: CompactType): number {
-  const compactH = compactType === "horizontal";
+export function bottom(layout: Layout): number {
   let max = 0,
-    bottomPos;
-
-  // we need some default, so take vertical?
-  let getBottomPos = item => item.y + item.h;
-  if (compactH) {
-    getBottomPos = item => item.x + item.w;
-  }
-
+    bottomY;
   for (let i = 0, len = layout.length; i < len; i++) {
-    bottomPos = getBottomPos(layout[i]);
-    if (bottomPos > max) max = bottomPos;
+    bottomY = layout[i].y + layout[i].h;
+    if (bottomY > max) max = bottomY;
   }
   return max;
 }
@@ -279,13 +270,12 @@ export function compactItem(
     // Bottom 'y' possible is the bottom of the layout.
     // This allows you to do nice stuff like specify {y: Infinity}
     // This is here because the layout must be sorted in order to get the correct bottom `y`.
-    l.y = Math.min(bottom(compareWith, compactType), l.y);
+    l.y = Math.min(bottom(compareWith), l.y);
     // Move the element up as far as it can go without colliding.
     while (l.y > 0 && !getFirstCollision(compareWith, l)) {
       l.y--;
     }
   } else if (compactH) {
-    l.x = Math.min(bottom(compareWith, compactType), l.x);
     // Move the element left as far as it can go without colliding.
     while (l.x > 0 && !getFirstCollision(compareWith, l)) {
       l.x--;

--- a/test/spec/utils-test.js
+++ b/test/spec/utils-test.js
@@ -381,7 +381,7 @@ describe("compact horizontal", () => {
   it("compact horizontal should remove empty horizontal space to left of item", () => {
     const layout = [{ x: 5, y: 5, w: 1, h: 1, i: "1" }];
     expect(compact(layout, "horizontal", 10)).toEqual([
-      { x: 0, y: 0, w: 1, h: 1, i: "1", moved: false, static: false }
+      { x: 0, y: 5, w: 1, h: 1, i: "1", moved: false, static: false }
     ]);
   });
 


### PR DESCRIPTION
Fixes #784 #1372 #1376

Horizontal compact mode should not compact vertically by reducing l.y by using the bottom function: It reduces the container and triggers items of the layout with the highest y values to reposition themselves because the repositioning is mixed with the horizontal compaction. So in my opinion, this one line of code needs to be removed (as done in this Pull Request).

Before:

https://user-images.githubusercontent.com/2151167/105766228-c5c9d900-5f59-11eb-8ee0-f9d34e48d88f.mp4

After:

https://user-images.githubusercontent.com/2151167/105766241-cbbfba00-5f59-11eb-81e2-7f9c212659f0.mp4

