### PR TITLE
Fixing the buggy drag container movement in scaled mode.

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -449,8 +449,8 @@ export default class GridItem extends React.Component<Props, State> {
   onDrag = (e: Event, { node, deltaX, deltaY }: ReactDraggableCallbackData) => {
     const { onDrag, transformScale } = this.props;
     if (!onDrag) return;
-    deltaX /= transformScale;
-    deltaY /= transformScale;
+    // deltaX /= transformScale;
+    // deltaY /= transformScale;
 
     if (!this.state.dragging) {
       throw new Error("onDrag called before onDragStart.");


### PR DESCRIPTION
When parent is scaled (like transform: scale(0.5)) then even after applying transformScale props, it was not proper dragging experience. After removing the above line it's working proper.

Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
