### PR TITLE
#1394 - Dynamic configuration of droppingItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ onResizeStart: ItemCallback,
 onResize: ItemCallback,
 // Calls when resize is complete.
 onResizeStop: ItemCallback,
+// Calls when an element is dragged over the grid from outsied
+// This callback should return an object to dynamically change the droppingItem size
+onDragOver: (e: DragOverEvent) => Object: { w: number, h: number };
 // Calls when an element has been dropped into the grid from outside.
 onDrop: (layout: Layout, item: ?LayoutItem, e: Event) => void
 

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -602,7 +602,11 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       width,
       containerPadding
     } = this.props;
-    const finalDroppingItem = onDragOver ? { ...droppingItem, ...onDragOver(e) } : droppingItem;
+    // Allow user to customize the dropping item or short-circuit the drop based on the results
+    // of the `onDragOver(e: Event)` callback.
+    const onDragOverResult = onDragOver?.(e);
+    if (onDragOverResult === false) return;
+    const finalDroppingItem = { ...droppingItem, ...onDragOverResult };
     
     const { layout } = this.state;
     // This is relative to the DOM element that this event fired for.

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -594,6 +594,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     const {
       droppingItem,
+      onDragOver,
       margin,
       cols,
       rowHeight,
@@ -601,6 +602,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       width,
       containerPadding
     } = this.props;
+    const finalDroppingItem = onDragOver ? { ...droppingItem, ...onDragOver(e) } : droppingItem;
+    
     const { layout } = this.state;
     // This is relative to the DOM element that this event fired for.
     const { layerX, layerY } = e.nativeEvent;
@@ -620,17 +623,17 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         positionParams,
         layerY,
         layerX,
-        droppingItem.w,
-        droppingItem.h
+        finalDroppingItem.w,
+        finalDroppingItem.h
       );
 
       this.setState({
-        droppingDOMNode: <div key={droppingItem.i} />,
+        droppingDOMNode: <div key={finalDroppingItem.i} />,
         droppingPosition,
         layout: [
           ...layout,
           {
-            ...droppingItem,
+            ...finalDroppingItem,
             x: calculatedPosition.x,
             y: calculatedPosition.y,
             static: false,


### PR DESCRIPTION
For issue #1394 
Idea here is to allow the `droppingItem` to be dynamically adjusted based on what is being dragged over.
Question - maybe we should prevent the `i` property from being overwritten (and limit it to `w` and `h`). I am not sure but dynamically changing `i` may cause issues for removing the placeholder. I don't see any use case for needing to change `i` anyway.

Example, in my particular use case the `onDropOver` handler may look like:

```js
const getDragData = e => e.dataTransfer.getData('dragData');
const evolveKeys => ({ minW: w, minH: h }) => ({ w, h })
const onDropOver = R.tryCatch(R.compose(evolveKeys, JSON.parse, getDragData),  () => ({ }));
```
