### PR TITLE
Add react and react-dom peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "react": ">= 16.3.0",
     "react-dom": ">= 16.3.0"
-  }
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,11 @@
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"
-  },
+  },  
+  "peerDependencies": {
+    "react": ">= 16.3.0",
+    "react-dom": ">= 16.3.0"
+  }
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
Fixes #1408

Copied the peer dependency definition from `react-draggable`, as that had the stricter version range of the two.