### PR TITLE
fix: add preventDefault() for chrome dropping from outside sometimes …

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -701,7 +701,9 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     }
   };
 
-  onDragEnter: () => void = () => {
+  onDragEnter: (e: Event) => void = (e: Event) => {
+    e.preventDefault();
+
     this.dragEnterCounter++;
   };
 


### PR DESCRIPTION
I am having this issue: #1442. 
![Peek 2021-04-16 00-31](https://user-images.githubusercontent.com/9444583/114907943-2debd500-9e4e-11eb-9cee-0e7375fdac5e.gif)
![Peek 2021-04-16 00-32](https://user-images.githubusercontent.com/9444583/114908044-478d1c80-9e4e-11eb-9f7c-59a035f620a3.gif)
(the above was modify from `15-drag-from-outside.jsx`)

This sometimes happens. My friend is on Mac, who doesn't seem to have this problem.
I am on Linux Chrome 89.0.4389.114.
Adding `e.preventDefault()` in onDragOver(already has that) and onDragEnter event works for me.
