### PR TITLE
WIP: Multiple React Grid Layout Drag and Drop

### DIFF
--- a/examples/vars.js
+++ b/examples/vars.js
@@ -160,5 +160,12 @@ module.exports = [
     paragraphs: [
       "This demonstrates how to compensate for a scaled parent."
     ]
+  },
+  {
+    title: "Multiple Layouts",
+    source: "multiple-layouts",
+    paragraphs: [
+      "This demonstrates how to use multiple layouts and drag between them"
+    ]
   }
 ];

--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -57,6 +57,7 @@ type Props = {
   rowHeight: number,
   maxRows: number,
   isDraggable: boolean,
+  isDetachable: booblean,
   isResizable: boolean,
   isBounded: boolean,
   static?: boolean,
@@ -172,6 +173,7 @@ export default class GridItem extends React.Component<Props, State> {
 
     // Flags
     isDraggable: PropTypes.bool.isRequired,
+    isDetachable: PropTypes.bool.isRequired,
     isResizable: PropTypes.bool.isRequired,
     isBounded: PropTypes.bool.isRequired,
     static: PropTypes.bool,
@@ -335,11 +337,12 @@ export default class GridItem extends React.Component<Props, State> {
    */
   mixinDraggable(
     child: ReactElement<any>,
-    isDraggable: boolean
+    isDraggable: boolean,
+    isDetachable: Boolean,
   ): ReactElement<any> {
     return (
       <DraggableCore
-        disabled={!isDraggable}
+        disabled={!isDraggable && !isDetachable}
         onStart={this.onDragStart}
         onDrag={this.onDrag}
         onStop={this.onDragStop}
@@ -616,6 +619,7 @@ export default class GridItem extends React.Component<Props, State> {
       w,
       h,
       isDraggable,
+      isDetachable,
       isResizable,
       droppingPosition,
       useCSSTransforms
@@ -652,14 +656,15 @@ export default class GridItem extends React.Component<Props, State> {
         ...this.props.style,
         ...child.props.style,
         ...this.createStyle(pos)
-      }
+      },
+      draggable: isDetachable
     });
 
     // Resizable support. This is usually on but the user can toggle it off.
     newChild = this.mixinResizable(newChild, pos, isResizable);
 
     // Draggable support. This is always on, except for with placeholders.
-    newChild = this.mixinDraggable(newChild, isDraggable);
+    newChild = this.mixinDraggable(newChild, isDraggable, isDetachable);
 
     return newChild;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,6 +131,19 @@ export function withLayoutItem(
   return [layout, item];
 }
 
+export function withinLayout(layout, element) {
+  const layoutCorners = layout.getBoundingClientRect();
+  const elementCorners = {
+    'x': element.clientX,
+    'y': element.clientY
+  };
+
+  return (elementCorners.x > layoutCorners.left &&
+    elementCorners.x < layoutCorners.right &&
+    elementCorners.y > layoutCorners.top &&
+    elementCorners.y < layoutCorners.bottom);
+}
+
 // Fast path to cloning, since this is monomorphic
 export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
   return {
@@ -328,11 +341,11 @@ export function compactItem(
       l.y++;
     }
   }
-  
+
   // Ensure that there are no negative positions
   l.y = Math.max(l.y, 0);
   l.x = Math.max(l.x, 0);
-  
+
   return l;
 }
 

--- a/test/examples/19-multiple-layouts.jsx
+++ b/test/examples/19-multiple-layouts.jsx
@@ -137,6 +137,7 @@ export default class MultipleLayout extends React.Component {
           compactType={this.state.compactType}
           preventCollision={!this.state.compactType}
           isDroppable={true}
+          isDetachable={true}
         >
           {this.generateDOM()}
         </ResponsiveReactGridLayout>
@@ -154,6 +155,7 @@ export default class MultipleLayout extends React.Component {
           compactType={this.state.compactType}
           preventCollision={!this.state.compactType}
           isDroppable={true}
+          isDetachable={true}
         >
           {this.generateDOM()}
         </ResponsiveReactGridLayout>

--- a/test/examples/19-multiple-layouts.jsx
+++ b/test/examples/19-multiple-layouts.jsx
@@ -1,0 +1,181 @@
+import React, { createRef } from "react";
+import _ from "lodash";
+import { Responsive, WidthProvider } from "react-grid-layout";
+const ResponsiveReactGridLayout = WidthProvider(Responsive);
+
+export default class MultipleLayout extends React.Component {
+  constructor(props) {
+    super(props);
+    this.dragApi = React.createRef();
+  }
+
+  static defaultProps = {
+    className: "layout",
+    rowHeight: 30,
+    onLayoutChange: function() {},
+    cols: { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 },
+  };
+
+  state = {
+    currentBreakpoint: "lg",
+    compactType: "vertical",
+    mounted: false,
+    layouts: { lg: generateLayout() }
+  };
+
+  componentDidMount() {
+    this.setState({ mounted: true });
+  }
+
+  generateDOM() {
+    return _.map(this.state.layouts.lg, function(l, i) {
+      return (
+        <div key={i} className={l.static ? "static" : ""}>
+          {l.static ? (
+            <span
+              className="text"
+              title="This item is static and cannot be removed or resized."
+            >
+              Static - {i}
+            </span>
+          ) : (
+            <span className="text">{i}</span>
+          )}
+        </div>
+      );
+    });
+  }
+
+  onBreakpointChange = breakpoint => {
+    this.setState({
+      currentBreakpoint: breakpoint
+    });
+  };
+
+  onCompactTypeChange = () => {
+    const { compactType: oldCompactType } = this.state;
+    const compactType =
+      oldCompactType === "horizontal"
+        ? "vertical"
+        : oldCompactType === "vertical"
+        ? null
+        : "horizontal";
+    this.setState({ compactType });
+  };
+
+  onLayoutChange = (layout, layouts) => {
+    this.props.onLayoutChange(layout, layouts);
+  };
+
+  onNewLayout = () => {
+    this.setState({
+      layouts: { lg: generateLayout() }
+    });
+  };
+
+  onDrop = (layout, layoutItem, _event) => {
+    alert(`Dropped element props:\n${JSON.stringify(layoutItem, ['x', 'y', 'w', 'h'], 2)}`);
+  };
+
+  onDrag = (layout, layoutItem, event) => {
+    if (this.dragApi.current) {
+      const { x, y } = event;
+      if (true) {
+        this.dragApi.current.dragIn({ i: 'id', w: 2, h: 2, node: event.target, position: { x, y }, event });
+      } else {
+        this.dragApi.current.dragOut({ position: { x, y }, event });
+      }
+    }
+  };
+
+  onDragStop = event => {
+    if (this.dragApi.current) {
+      this.dragApi.current.stop({ position: getPosition(event), event });
+    }
+  };
+
+  render() {
+    return (
+      <div>
+        <div>
+          Current Breakpoint: {this.state.currentBreakpoint} (
+          {this.props.cols[this.state.currentBreakpoint]} columns)
+        </div>
+        <div>
+          Compaction type:{" "}
+          {_.capitalize(this.state.compactType) || "No Compaction"}
+        </div>
+        <button onClick={this.onNewLayout}>Generate New Layout</button>
+        <button onClick={this.onCompactTypeChange}>
+          Change Compaction Type
+        </button>
+        <div
+          className="droppable-element"
+          draggable={true}
+          unselectable="on"
+          // this is a hack for firefox
+          // Firefox requires some kind of initialization
+          // which we can do by adding this attribute
+          // @see https://bugzilla.mozilla.org/show_bug.cgi?id=568313
+          onDragStart={e => e.dataTransfer.setData("text/plain", "")}
+        >
+          Droppable Element (Drag me!)
+        </div>
+        <ResponsiveReactGridLayout
+          {...this.props}
+          layouts={this.state.layouts}
+          onBreakpointChange={this.onBreakpointChange}
+          onLayoutChange={this.onLayoutChange}
+          dragApiRef={this.dragApi}
+          onDrop={this.onDrop}
+          // onDrag={this.onDrag}
+          // WidthProvider option
+          measureBeforeMount={false}
+          // I like to have it animate on mount. If you don't, delete `useCSSTransforms` (it's default `true`)
+          // and set `measureBeforeMount={true}`.
+          useCSSTransforms={this.state.mounted}
+          compactType={this.state.compactType}
+          preventCollision={!this.state.compactType}
+          isDroppable={true}
+        >
+          {this.generateDOM()}
+        </ResponsiveReactGridLayout>
+        <ResponsiveReactGridLayout
+          {...this.props}
+          layouts={this.state.layouts}
+          onBreakpointChange={this.onBreakpointChange}
+          onLayoutChange={this.onLayoutChange}
+          onDrop={this.onDrop}
+          // WidthProvider option
+          measureBeforeMount={false}
+          // I like to have it animate on mount. If you don't, delete `useCSSTransforms` (it's default `true`)
+          // and set `measureBeforeMount={true}`.
+          useCSSTransforms={this.state.mounted}
+          compactType={this.state.compactType}
+          preventCollision={!this.state.compactType}
+          isDroppable={true}
+        >
+          {this.generateDOM()}
+        </ResponsiveReactGridLayout>
+      </div>
+    );
+  }
+}
+
+function generateLayout() {
+  return _.map(_.range(0, 6), function(item, i) {
+    var y = Math.ceil(Math.random() * 4) + 1;
+    return {
+      x: Math.round(Math.random() * 5) * 2,
+      y: Math.floor(i / 6) * y,
+      w: 2,
+      h: y,
+      i: i.toString(),
+      static: Math.random() < 0.05
+    };
+  });
+}
+
+if (process.env.STATIC_EXAMPLES === true) {
+  import("../test-hook.jsx").then(fn => fn.default(MultipleLayout));
+}


### PR DESCRIPTION
![Peek 2021-04-26 12-17](https://user-images.githubusercontent.com/5080145/116138273-75ae0000-a689-11eb-9101-0afadcface8e.gif)

## What has been done
- Added a new `isDetachable` prop that will dictate whether or not you are able to detach a block from a RGL and add it to another RGL.
- A bunch of development `console.log`
- Example 19 to test out dragging between sections

## What still needs to be done
- Drag API that will allow you to access the layout of the block being dragged
- Update example to have a container state that keeps track of the layouts + blocks of each RGL
- Update example so that the block being dragged from one RGL to another will be removed from the original and added to the new RGL
- Add tests to make sure the existing functionality of RGL is not impacted
- Make sure existing drag within section functionality is still working
- Clean up any development logs

## How to develop
- Ask me to add you to the repo so you can edit
- Run `npm run view-example` to load the development server
- Navigate to example 19
- Make changes and things will auto rebuild