### PR TITLE
fix: Remove sorting when compact type is null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -626,7 +626,8 @@ export function sortLayoutItems(
   compactType: CompactType
 ): Layout {
   if (compactType === "horizontal") return sortLayoutItemsByColRow(layout);
-  else return sortLayoutItemsByRowCol(layout);
+  if (compactType === "vertical") return sortLayoutItemsByRowCol(layout);
+  else return layout;
 }
 
 /**


### PR DESCRIPTION
When compact type is null, no sorting is required. 
The unexpected sorting off the layout, cause it to change when dragging in an new element, even with preventCollision is true.

Fixes issue #1473
