### PR TITLE
compactItem: support decimal fractions in width and height

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -304,12 +304,12 @@ export function compactItem(
     // This is here because the layout must be sorted in order to get the correct bottom `y`.
     l.y = Math.min(bottom(compareWith), l.y);
     // Move the element up as far as it can go without colliding.
-    while (l.y > 0 && !getFirstCollision(compareWith, l)) {
+    while (l.y >= 1 && !getFirstCollision(compareWith, l)) {
       l.y--;
     }
   } else if (compactH) {
     // Move the element left as far as it can go without colliding.
-    while (l.x > 0 && !getFirstCollision(compareWith, l)) {
+    while (l.x >= 1 && !getFirstCollision(compareWith, l)) {
       l.x--;
     }
   }


### PR DESCRIPTION
Proposing this solution for issue https://github.com/react-grid-layout/react-grid-layout/issues/1498

This is to support decimal fractions for `h` and `w` values for items in layout property passed to ResponsiveGridLayout
