### PR TITLE
Remove existing placeholder when onDropDragOver return false

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -647,7 +647,12 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     // Allow user to customize the dropping item or short-circuit the drop based on the results
     // of the `onDragOver(e: Event)` callback.
     const onDragOverResult = onDropDragOver?.(e);
-    if (onDragOverResult === false) return false;
+    if (onDragOverResult === false) {
+      if (this.state.droppingDOMNode) {
+        this.removeDroppingPlaceholder();
+      }
+      return false;
+    }
     const finalDroppingItem = { ...droppingItem, ...onDragOverResult };
 
     const { layout } = this.state;


### PR DESCRIPTION
Resolves issue [1511](https://github.com/react-grid-layout/react-grid-layout/issues/1511)
