### PR TITLE
Fix drop dragover not obeying transformScale

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -642,7 +642,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       rowHeight,
       maxRows,
       width,
-      containerPadding
+      containerPadding,
+      transformScale
     } = this.props;
     // Allow user to customize the dropping item or short-circuit the drop based on the results
     // of the `onDragOver(e: Event)` callback.
@@ -658,7 +659,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const { layout } = this.state;
     // This is relative to the DOM element that this event fired for.
     const { layerX, layerY } = e.nativeEvent;
-    const droppingPosition = { left: layerX, top: layerY, e };
+    const droppingPosition = { left: layerX / transformScale, top: layerY / transformScale, e };
 
     if (!this.state.droppingDOMNode) {
       const positionParams: PositionParams = {


### PR DESCRIPTION
Fixes issue #1522 

The position given to us from the drag-drop event was not being scaled by the appropriate `transformScale`.