### PR TITLE
Fix dragover positioning when using CSS translation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,8 +50,8 @@ export type GridDragEvent = {
 export type GridResizeEvent = { e: Event, node: HTMLElement, size: Size };
 export type DragOverEvent = MouseEvent & {
   nativeEvent: {
-    layerX: number,
-    layerY: number,
+    clientX: number,
+    clientY: number,
     ...Event
   }
 };

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -102,8 +102,8 @@ describe("Lifecycle tests", function () {
         TestUtils.Simulate.dragOver(gridLayout.getDOMNode(), {
           nativeEvent: {
             target: droppable.getDOMNode(),
-            layerX: x,
-            layerY: y
+            clientX: x,
+            clientY: y
           }
         });
       }


### PR DESCRIPTION
__The Problems:__
When the grid is translated with a CSS transform the calculated dragover positions were being miscalculated within the grid.

This happens because `layerX` and `layerY` in the native event are not relative to the translated element, they are relative to the "layer" but the layer is not translated. So for example: If the grid is translated to (100px, 100px) and you then drag a new droppable into the grid at its top-left corner then `layerX` and `layerY` report (100,100) instead of (0,0) so both the placeholder and grid item are misplaced.

Also `layerX` and `layerY` are [not standard event fields](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/layerX) so differnet browsers may behave differently around this issue.

__The Solution:__
This PR implements a solution by measuring the final client (AKA on-screen) position of the grid (which takes into account the CSS transform) and compares that with `clientX` and `clientY` fields from the event to calculate the relative offset within the grid.

__Possible areas for improvement:__
1. This now calls `getBoundingClientRect` on every DragOverEvent. Unless we expect the grid to be moving at the same time then we could call it once and cache the result. Having said that I have not observed a perf impact.
2. This is quite similar to the implementation used in [`DragItem.onDragStart`](https://github.com/react-grid-layout/react-grid-layout/blob/9bf5942c06693ce31d88d8cf9849b1f56bb6c9b6/lib/GridItem.jsx#L432) but with some notable differences. I wonder if/how they could be common'd out and whether this PR should be factoring in `scrollLeft` and `scrollTop` too?
3. I noticed a [Firefox specific hack to fix event flickering](https://github.com/react-grid-layout/react-grid-layout/blob/9bf5942c06693ce31d88d8cf9849b1f56bb6c9b6/lib/ReactGridLayout.jsx#L604) which I suspect may also be resolved by this PR now that we use the better-defined `clientX` and `clientY` in screenspace and is no longer sensitive to whether the event target is the grid or a child of the grid.