### PR TITLE
onResizeStop and onDragStop callbacks should return updated layout

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -348,12 +348,13 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       allowOverlap
     );
 
-    this.props.onDragStop(layout, oldDragItem, l, null, e, node);
-
     // Set state
     const newLayout = allowOverlap
       ? layout
       : compact(layout, compactType(this.props), cols);
+
+    this.props.onDragStop(newLayout, oldDragItem, l, null, e, node);
+
     const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,
@@ -468,12 +469,13 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const { cols, allowOverlap } = this.props;
     const l = getLayoutItem(layout, i);
 
-    this.props.onResizeStop(layout, oldResizeItem, l, null, e, node);
-
     // Set state
     const newLayout = allowOverlap
       ? layout
       : compact(layout, compactType(this.props), cols);
+
+    this.props.onResizeStop(newLayout, oldResizeItem, l, null, e, node);
+
     const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,


### PR DESCRIPTION
I'm not sure why a callback for changing state would return the old state that we already have. In my opinion this should be returning the updated layout state.