### PR TITLE
Fix Npm build - remove coverage folder (-60%size) - move eslint parser to devDependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+coverage/
 test/
 examples/
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/STRML/react-grid-layout",
   "dependencies": {
-    "@babel/eslint-parser": "^7.16.3",
     "clsx": "^1.1.1",
     "lodash.isequal": "^4.0.0",
     "prop-types": "^15.0.0",
@@ -47,6 +46,7 @@
   "devDependencies": {
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.15.0",
+    "@babel/eslint-parser": "^7.16.3",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "@babel/plugin-transform-flow-comments": "^7.14.5",
     "@babel/preset-env": "^7.15.0",


### PR DESCRIPTION
Hi guys,
First of all, I have to say thank you for this great library!

This PR fixes two small bugs on the Npm build side:
- remove coverage folder (-60%size) 
- move "@babel/eslint-parser" to devDependencies.

Regards!
