### PR TITLE
Add enableUserSelectHack prop to answer a possible performance issue

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -70,6 +70,7 @@ type Props = {
   // Draggability
   cancel: string,
   handle: string,
+  enableUserSelectHack?: boolean,
 
   x: number,
   y: number,
@@ -186,6 +187,8 @@ export default class GridItem extends React.Component<Props, State> {
     handle: PropTypes.string,
     // Selector for draggable cancel (see react-draggable)
     cancel: PropTypes.string,
+    // Select hack to disable if performance issues (see react-draggable)
+    enableUserSelectHack: PropTypes.bool,
     // Current position of a dropping element
     droppingPosition: PropTypes.shape({
       e: PropTypes.object.isRequired,
@@ -350,6 +353,7 @@ export default class GridItem extends React.Component<Props, State> {
         }
         scale={this.props.transformScale}
         nodeRef={this.elementRef}
+        enableUserSelectHack={this.props.enableUserSelectHack}
       >
         {child}
       </DraggableCore>


### PR DESCRIPTION
`react-draggable` uses a hack to hide the user selection during drag.
This hack consists in applying a rule (`all: inherit`) to every `body` children's selection. This can create a lag spike.
I fixed it by adding the necessary prop to pass to react-draggable.

I'm creating this PR along with an [issue](https://github.com/react-grid-layout/react-grid-layout/issues/1659).