### PR TITLE
Fix compactItem for case when allowOverlap is true and compactType is null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -316,7 +316,7 @@ export function compactItem(
 
   // Move it down, and keep moving it down if it's colliding.
   let collides;
-  while ((collides = getFirstCollision(compareWith, l))) {
+  while ((collides = getFirstCollision(compareWith, l)) && compactType) {
     if (compactH) {
       resolveCompactionCollision(fullLayout, l, collides.x + collides.w, "x");
     } else {


### PR DESCRIPTION
Fixes #1649 

Avoids entering collision loop when allowOverlap is true and compactType is null.