### PR TITLE
Avoid unwanted re-render on resize

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -79,7 +79,9 @@ export default function WidthProvideRGL<Config>(
       // fix: grid position error when node or parentNode display is none by window resize
       // #924 #1084
       if (node instanceof HTMLElement && node.offsetWidth) {
-        this.setState({ width: node.offsetWidth });
+        this.setState(previousState => previousState.width !== node.offsetWidth
+          ? { width: node.offsetWidth }
+          : previousState);
       }
     };
 


### PR DESCRIPTION
While digging into the source code of the library to investigate a runtime crash I had in one of my app, I found this quick optimization. I though it could still be useful to share it but feel free to reject it if it does not make sense.

---

Up-to-now the current implementation watches the event `onWindowResize` and triggers a state update anytime it receives an event related to resize even if the size of the offset was not updated.

The PR just removes this unneeded re-render by not updating the state in such case.
