### PR TITLE
Avoid possible stack overflows into `resolveCompactionCollision`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,35 +252,41 @@ function resolveCompactionCollision(
   moveToCoord: number,
   axis: "x" | "y"
 ) {
-  const sizeProp = heightWidth[axis];
-  item[axis] += 1;
-  const itemIndex = layout
-    .map(layoutItem => {
-      return layoutItem.i;
-    })
-    .indexOf(item.i);
+  // Instead of performing recursive calls to the function itself
+  // we will handle the recursion via a local stack. It makes recursion
+  // able to go further and thus avoid possible stack overflows due to
+  // configurations containing huge amounts of collisions.
+  const stack = [{ item, moveToCoord }];
+  while (stack.length !== 0) {
+    const { item: currentItem, moveToCoord: currentMoveToCoord } = stack.pop();
+    const sizeProp = heightWidth[axis];
+    currentItem[axis] += 1;
+    const itemIndex = layout
+      .map(layoutItem => {
+        return layoutItem.i;
+      })
+      .indexOf(currentItem.i);
 
-  // Go through each item we collide with.
-  for (let i = itemIndex + 1; i < layout.length; i++) {
-    const otherItem = layout[i];
-    // Ignore static items
-    if (otherItem.static) continue;
+    // Go through each item we collide with.
+    for (let i = itemIndex + 1; i < layout.length; i++) {
+      const otherItem = layout[i];
+      // Ignore static items
+      if (otherItem.static) continue;
 
-    // Optimization: we can break early if we know we're past this el
-    // We can do this b/c it's a sorted layout
-    if (otherItem.y > item.y + item.h) break;
+      // Optimization: we can break early if we know we're past this el
+      // We can do this b/c it's a sorted layout
+      if (otherItem.y > currentItem.y + currentItem.h) break;
 
-    if (collides(item, otherItem)) {
-      resolveCompactionCollision(
-        layout,
-        otherItem,
-        moveToCoord + item[sizeProp],
-        axis
-      );
+      if (collides(currentItem, otherItem)) {
+        stack.push({
+          item: otherItem,
+          moveToCoord: currentMoveToCoord + currentItem[sizeProp]
+        });
+      }
     }
-  }
 
-  item[axis] = moveToCoord;
+    currentItem[axis] = currentMoveToCoord;
+  }
 }
 
 /**


### PR DESCRIPTION
While running `react-grid-layout` on one of my project, I encountered a case leading `resolveCompactionCollision` into a stack overflow. The reason being that the cursion had to apply on too many colliding items and thus led us to a runtime crash.

The current PR changes the implementation of the algorithm into a non recursive version by replacing the native stack handled by the browser (and pretty limited in size) my a manually handled one backed by an array and behaving exactly the same way.