### PR TITLE
Add checking the compactType null value to avoid breaking the layout when overlapping is allowed.

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -713,7 +713,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const newLayout = compact(
       layout.filter(l => l.i !== droppingItem.i),
       compactType(this.props),
-      cols
+      cols,
+      this.props.allowOverlap
     );
 
     this.setState({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -316,7 +316,7 @@ export function compactItem(
 
   // Move it down, and keep moving it down if it's colliding.
   let collides;
-  while ((collides = getFirstCollision(compareWith, l))) {
+  while ((collides = getFirstCollision(compareWith, l)) && compactType !== null) {
     if (compactH) {
       resolveCompactionCollision(fullLayout, l, collides.x + collides.w, "x");
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,12 +206,14 @@ export function collides(l1: LayoutItem, l2: LayoutItem): boolean {
  * @param  {Array} layout Layout.
  * @param  {Boolean} verticalCompact Whether or not to compact the layout
  *   vertically.
+ * @param  {Boolean} allowOverlap When `true`, allows overlapping grid items.
  * @return {Array}       Compacted Layout.
  */
 export function compact(
   layout: Layout,
   compactType: CompactType,
-  cols: number
+  cols: number,
+  allowOverlap: ?boolean
 ): Layout {
   // Statics go in the compareWith array right away so items flow around them.
   const compareWith = getStatics(layout);
@@ -225,7 +227,7 @@ export function compact(
 
     // Don't move static elements
     if (!l.static) {
-      l = compactItem(compareWith, l, compactType, cols, sorted);
+      l = compactItem(compareWith, l, compactType, cols, sorted, allowOverlap);
 
       // Add to comparison array. We only collide with items before this one.
       // Statics are already in this array.
@@ -294,7 +296,8 @@ export function compactItem(
   l: LayoutItem,
   compactType: CompactType,
   cols: number,
-  fullLayout: Layout
+  fullLayout: Layout,
+  allowOverlap: ?boolean
 ): LayoutItem {
   const compactV = compactType === "vertical";
   const compactH = compactType === "horizontal";
@@ -316,7 +319,8 @@ export function compactItem(
 
   // Move it down, and keep moving it down if it's colliding.
   let collides;
-  while ((collides = getFirstCollision(compareWith, l)) && compactType !== null) {
+  // Checking the compactType null value to avoid breaking the layout when overlapping is allowed.
+  while ((collides = getFirstCollision(compareWith, l)) && !(compactType === null && allowOverlap)) {
     if (compactH) {
       resolveCompactionCollision(fullLayout, l, collides.x + collides.w, "x");
     } else {


### PR DESCRIPTION

When allowOverlap is true and compactType is null, the layout is unintentionally transformed like the AS-IS gif.

![AS-IS](https://user-images.githubusercontent.com/6470409/195252491-958d78a8-2b6f-4ddd-b1a2-e08c39638c85.gif)

Adding an exception when compactType is null in compactItem avoids unintended layout transformed.

![PR](https://user-images.githubusercontent.com/6470409/195252454-cb85b787-0d5d-4247-a15c-f2f2d4dea63c.gif)
