### PR TITLE
feat: Add onLayoutInit callback

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -107,6 +107,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       w: 1
     },
     resizeHandles: ["se"],
+    onLayoutInit: noop,
     onLayoutChange: noop,
     onDragStart: noop,
     onDrag: noop,
@@ -143,6 +144,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     // Possibly call back with layout on mount. This should be done after correcting the layout width
     // to ensure we don't rerender with the wrong width.
     this.onLayoutMaybeChanged(this.state.layout, this.props.layout);
+    this.props.onLayoutInit(this.state.layout)
   }
 
   static getDerivedStateFromProps(

--- a/lib/ReactGridLayoutPropTypes.js
+++ b/lib/ReactGridLayoutPropTypes.js
@@ -81,6 +81,7 @@ export type Props = {|
   allowOverlap: boolean,
 
   // Callbacks
+  onLayoutInit: Layout => void,
   onLayoutChange: Layout => void,
   onDrag: EventCallback,
   onDragStart: EventCallback,
@@ -196,6 +197,8 @@ export default {
   // Callbacks
   //
 
+  // Callback returning the computed layout after component mount
+  onLayoutInit: PropTypes.func,
   // Callback so you can save the layout. Calls after each drag & resize stops.
   onLayoutChange: PropTypes.func,
 

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -63,6 +63,7 @@ type Props<Breakpoint: string = string> = {|
 
   // Callbacks
   onBreakpointChange: (Breakpoint, cols: number) => void,
+  onLayoutInit?: ?(layout: Layout) => void,
   onLayoutChange: OnLayoutChangeCallback,
   onWidthChange: (
     containerWidth: number,
@@ -83,6 +84,7 @@ type DefaultProps = Pick<
     margin: 0,
     onBreakpointChange: 0,
     onLayoutChange: 0,
+    onLayoutInit: 0,
     onWidthChange: 0
   |}
 >;
@@ -243,6 +245,12 @@ export default class ResponsiveReactGridLayout extends React.Component<
     });
   };
 
+  onLayoutInit : Layout => void = (layout: Layout) => {
+    if(this.props.onLayoutInit){
+      this.props.onLayoutInit(layout);
+    }
+  }
+
   /**
    * When the width changes work through breakpoints and reset state with the new width & breakpoint.
    * Width changes are necessary to figure out the widget widths.
@@ -341,6 +349,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
           this.state.breakpoint
         )}
         onLayoutChange={this.onLayoutChange}
+        onLayoutInit={this.onLayoutInit}
         layout={this.state.layout}
         cols={this.state.cols}
       />


### PR DESCRIPTION
This work aims to add an `onLayoutInit` callback, that is called inside the componentDidMount, once the layout has been possibly corrected.
