### PR TITLE
Replace `lodash.isequal` to `fast-equals`

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import isEqual from "lodash.isequal";
+import { deepEqual } from "fast-equals";
 import clsx from "clsx";
 import {
   bottom,
@@ -158,7 +158,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     // Legacy support for compactType
     // Allow parent to set layout directly.
     if (
-      !isEqual(nextProps.layout, prevState.propsLayout) ||
+      !deepEqual(nextProps.layout, prevState.propsLayout) ||
       nextProps.compactType !== prevState.compactType
     ) {
       newLayoutBase = nextProps.layout;
@@ -198,7 +198,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       // from SCU is if the user intentionally memoizes children. If they do, and they can
       // handle changes properly, performance will increase.
       this.props.children !== nextProps.children ||
-      !fastRGLPropsEqual(this.props, nextProps, isEqual) ||
+      !fastRGLPropsEqual(this.props, nextProps, deepEqual) ||
       this.state.activeDrag !== nextState.activeDrag ||
       this.state.mounted !== nextState.mounted ||
       this.state.droppingPosition !== nextState.droppingPosition
@@ -368,7 +368,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
   onLayoutMaybeChanged(newLayout: Layout, oldLayout: ?Layout) {
     if (!oldLayout) oldLayout = this.state.layout;
 
-    if (!isEqual(oldLayout, newLayout)) {
+    if (!deepEqual(oldLayout, newLayout)) {
       this.props.onLayoutChange(newLayout);
     }
   }

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import PropTypes from "prop-types";
-import isEqual from "lodash.isequal";
+import { deepEqual } from "fast-equals";
 
 import {
   cloneLayout,
@@ -203,7 +203,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
     nextProps: Props<*>,
     prevState: State
   ): ?$Shape<State> {
-    if (!isEqual(nextProps.layouts, prevState.layouts)) {
+    if (!deepEqual(nextProps.layouts, prevState.layouts)) {
       // Allow parent to set layouts directly.
       const { breakpoint, cols } = prevState;
 
@@ -228,8 +228,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
     if (
       this.props.width != prevProps.width ||
       this.props.breakpoint !== prevProps.breakpoint ||
-      !isEqual(this.props.breakpoints, prevProps.breakpoints) ||
-      !isEqual(this.props.cols, prevProps.cols)
+      !deepEqual(this.props.breakpoints, prevProps.breakpoints) ||
+      !deepEqual(this.props.cols, prevProps.cols)
     ) {
       this.onWidthChange(prevProps);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 // @flow
-import isEqual from "lodash.isequal";
+import { deepEqual } from "fast-equals";
 import React from "react";
 import type {
   ChildrenArray as ReactChildrenArray,
@@ -158,7 +158,7 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
  * This will catch differences in keys, order, and length.
  */
 export function childrenEqual(a: ReactChildren, b: ReactChildren): boolean {
-  return isEqual(
+  return deepEqual(
     React.Children.map(a, c => c?.key),
     React.Children.map(b, c => c?.key)
   );

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/STRML/react-grid-layout",
   "dependencies": {
     "clsx": "^1.2.1",
-    "lodash.isequal": "^4.0.0",
+    "fast-equals": "^5.0.0",
     "prop-types": "^15.8.1",
     "react-draggable": "^4.4.5",
     "react-resizable": "^3.0.4"

--- a/test/spec/utils-test.js
+++ b/test/spec/utils-test.js
@@ -17,7 +17,7 @@ import {
   calcWH,
   calcXY
 } from "../../lib/calculateUtils";
-import isEqual from "lodash.isequal";
+import { deepEqual } from "fast-equals";
 import deepFreeze from "./../util/deepFreeze";
 
 describe("bottom", () => {
@@ -590,7 +590,7 @@ describe("fastRGLPropsEqual", () => {
       margin: [10, 10],
       style: { background: "red" }
     };
-    expect(fastRGLPropsEqual(props1, props2, isEqual)).toEqual(true);
+    expect(fastRGLPropsEqual(props1, props2, deepEqual)).toEqual(true);
   });
 
   it("catches changed arrays", () => {
@@ -600,7 +600,7 @@ describe("fastRGLPropsEqual", () => {
     const props2 = {
       margin: [10, 11]
     };
-    expect(fastRGLPropsEqual(props1, props2, isEqual)).toEqual(false);
+    expect(fastRGLPropsEqual(props1, props2, deepEqual)).toEqual(false);
   });
 
   it("ignores children", () => {
@@ -610,7 +610,7 @@ describe("fastRGLPropsEqual", () => {
     const props2 = {
       children: ["biff", "bar"]
     };
-    expect(fastRGLPropsEqual(props1, props2, isEqual)).toEqual(true);
+    expect(fastRGLPropsEqual(props1, props2, deepEqual)).toEqual(true);
   });
 
   it("fails added props", () => {
@@ -618,7 +618,7 @@ describe("fastRGLPropsEqual", () => {
     const props2 = {
       droppingItem: { w: 1, h: 2, i: 3 }
     };
-    expect(fastRGLPropsEqual(props1, props2, isEqual)).toEqual(false);
+    expect(fastRGLPropsEqual(props1, props2, deepEqual)).toEqual(false);
   });
 
   it("ignores invalid props", () => {
@@ -626,7 +626,7 @@ describe("fastRGLPropsEqual", () => {
     const props2 = {
       somethingElse: { w: 1, h: 2, i: 3 }
     };
-    expect(fastRGLPropsEqual(props1, props2, isEqual)).toEqual(true);
+    expect(fastRGLPropsEqual(props1, props2, deepEqual)).toEqual(true);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3404,6 +3404,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-equals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.0.0.tgz#e79b78d24404758cbce747626b3601cd06869785"
+  integrity sha512-CjA/zqeRc1HUzFu0EIvPmcvJEQnt8+PmeeEpCKyw79ssvvGYcb70a4uSn5qb410AULdewthkKyGuz+RbjHkLfw==
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4890,7 +4895,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
 
-lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==


### PR DESCRIPTION
Suggestion to replace `lodash.isequal` to well-maintained faster implementation.
