### PR TITLE
fix(build): npm@9 removed `npm bin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .DELETE_ON_ERROR:
 
-export BIN := $(shell npm bin)
-PATH := $(BIN):$(PATH)
+EXEC = npm exec --
 DIST = ./dist
 BUILD = ./build
 LIB = ./lib
@@ -18,7 +17,7 @@ clean:
 	rm -rf $(BUILD) $(DIST)
 
 dev:
-	@$(BIN)/webpack serve --config webpack-dev-server.config.js \
+	@$(EXEC) webpack serve --config webpack-dev-server.config.js \
 	  --hot --progress
 
 # Allows usage of `make install`, `make link`
@@ -27,37 +26,37 @@ install link:
 
 # Build browser module
 dist/%.min.js: $(LIB) $(BIN)
-	@$(BIN)/webpack
+	@$(EXEC) webpack
 
 build-js:
-	@$(BIN)/babel --out-dir $(BUILD) $(LIB)
+	@$(EXEC) babel --out-dir $(BUILD) $(LIB)
 
 # Will build for use on github pages. Full url of page is
 # https://react-grid-layout.github.io/react-grid-layout/examples/0-showcase.html
 # so the CONTENT_BASE should adapt.
 build-example:
-	@$(BIN)/webpack --config webpack-examples.config.js
+	@$(EXEC) webpack --config webpack-examples.config.js
 	env CONTENT_BASE="/react-grid-layout/examples/" node ./examples/generate.js
 
 # Note: this doesn't hot reload, you need to re-run to update files.
 # TODO fix that
 view-example:
 	env CONTENT_BASE="/react-grid-layout/examples/" node ./examples/generate.js
-	@$(BIN)/webpack serve --config webpack-examples.config.js --progress
+	@$(EXEC) webpack serve --config webpack-examples.config.js --progress
 
 # FIXME flow is usually global
 lint:
-	@$(BIN)/flow
-	@$(BIN)/eslint --ext .js,.jsx
+	@$(EXEC) flow
+	@$(EXEC) eslint --ext .js,.jsx
 
 test:
-	env NODE_ENV=test $(BIN)/jest --coverage
+	env NODE_ENV=test $(EXEC) jest --coverage
 
 test-watch:
-	env NODE_ENV=test $(BIN)/jest --watch
+	env NODE_ENV=test $(EXEC) jest --watch
 
 test-update-snapshots:
-	env NODE_ENV=test $(BIN)/jest --updateSnapshot
+	env NODE_ENV=test $(EXEC) jest --updateSnapshot
 
 release-patch: build lint test
 	@$(call release,patch)


### PR DESCRIPTION
[npm@9 removed `npm bin`](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/#%E2%9A%A0%EF%B8%8F-notable-breaking-changes)

Moved to `npm exec -- $(cmd)`

Fixes #1902
