### PR TITLE
Export calculateUtils

### DIFF
--- a/index-dev.js
+++ b/index-dev.js
@@ -1,5 +1,6 @@
 module.exports = require("./lib/ReactGridLayout").default;
 module.exports.utils = require("./lib/utils");
+module.exports.calculateUtils = require("./lib/calculateUtils");
 module.exports.Responsive = require("./lib/ResponsiveReactGridLayout").default;
 module.exports.Responsive.utils = require("./lib/responsiveUtils");
 module.exports.WidthProvider =

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = require("./build/ReactGridLayout").default;
 module.exports.utils = require("./build/utils");
+module.exports.calculateUtils = require("./build/calculateUtils");
 module.exports.Responsive =
   require("./build/ResponsiveReactGridLayout").default;
 module.exports.Responsive.utils = require("./build/responsiveUtils");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ import type {
   ChildrenArray as ReactChildrenArray,
   Element as ReactElement
 } from "react";
+export * as calculateUtils from "./calculateUtils";
 export type LayoutItem = {
   w: number,
   h: number,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@ import type {
   ChildrenArray as ReactChildrenArray,
   Element as ReactElement
 } from "react";
-export * as calculateUtils from "./calculateUtils";
 export type LayoutItem = {
   w: number,
   h: number,


### PR DESCRIPTION
## Goal
export `calculateUtils`.

## Reasoning
We've found this utils useful when writing some custom `onResize` and `onDrag` implementations. Currently we just copied the utils to reuse them, but figured it'd make more sense to just export them (and likely useful to others as well).

This also helps ensure these calculations are consistent both within the library and for any external consumers looking to augment the default behaviour.

## Other considerations
One potential downside is that many of these utils require consumers to pass `positionParams` as an argument. While this isn't bad (the user has all this information), it does feel like an extra step. I wonder if there is a way to expose something like `getPositionParams` from `GridItem` to make this cleaner?

However, something like that would require exposing a RGL instance and having a method hung off that (since all the positional information is relative to the associated grid). Probably outside of the scope of this PR, but something I figured I'd mention just incase you have any thoughts.
