### PR TITLE
fix: set activeDrag in the state onDragStart

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -249,10 +249,21 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const { layout } = this.state;
     const l = getLayoutItem(layout, i);
     if (!l) return;
+    
+    // Create placeholder (display only)
+    const placeholder = {
+      w: l.w,
+      h: l.h,
+      x: l.x,
+      y: l.y,
+      placeholder: true,
+      i: i
+    };
 
     this.setState({
       oldDragItem: cloneLayoutItem(l),
-      oldLayout: layout
+      oldLayout: layout,
+      activeDrag: placeholder
     });
 
     return this.props.onDragStart(layout, l, l, null, e, node);


### PR DESCRIPTION
this fixes a problem where clicking on the drag handle triggers onDragStart and doesn't trigger onDragStop as the activeDrag was being set only onDrag and not onDragStart as well. another solution would be to remove the check for activeDrag in the onDragStop function.

https://github.com/react-grid-layout/react-grid-layout/issues/1745
