### PR TITLE
fix(resize): fix bug where height could not be resized if h=0

### DIFF
--- a/lib/ReactGridLayoutPropTypes.js
+++ b/lib/ReactGridLayoutPropTypes.js
@@ -11,7 +11,8 @@ import type {
   EventCallback,
   CompactType,
   Layout,
-  LayoutItem
+  LayoutItem,
+  ResizeHandleAxis
 } from "./utils";
 
 // util
@@ -19,15 +20,6 @@ export type ReactRef<T: HTMLElement> = {|
   +current: T | null
 |};
 
-export type ResizeHandleAxis =
-  | "s"
-  | "w"
-  | "e"
-  | "n"
-  | "sw"
-  | "nw"
-  | "se"
-  | "ne";
 export type ResizeHandle =
   | ReactElement<any>
   | ((

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,17 @@ import type {
   ChildrenArray as ReactChildrenArray,
   Element as ReactElement
 } from "react";
+
+export type ResizeHandleAxis =
+  | "s"
+  | "w"
+  | "e"
+  | "n"
+  | "sw"
+  | "nw"
+  | "se"
+  | "ne";
+
 export type LayoutItem = {
   w: number,
   h: number,
@@ -19,7 +30,7 @@ export type LayoutItem = {
   static?: boolean,
   isDraggable?: ?boolean,
   isResizable?: ?boolean,
-  resizeHandles?: Array<"s" | "w" | "e" | "n" | "sw" | "nw" | "se" | "ne">,
+  resizeHandles?: Array<ResizeHandleAxis>,
   isBounded?: ?boolean
 };
 export type Layout = $ReadOnlyArray<LayoutItem>;
@@ -659,6 +670,126 @@ export function moveElementAwayFromCollision(
  */
 export function perc(num: number): string {
   return num * 100 + "%";
+}
+
+/**
+ * Helper functions to constrain dimensions of a GridItem
+ */
+const constrainWidth = (
+  left: number,
+  currentWidth: number,
+  newWidth: number,
+  containerWidth: number
+) => {
+  return left + newWidth > containerWidth ? currentWidth : newWidth;
+};
+
+const constrainHeight = (
+  top: number,
+  currentHeight: number,
+  newHeight: number
+) => {
+  return top < 0 ? currentHeight : newHeight;
+};
+
+const constrainLeft = (left: number) => Math.max(0, left);
+
+const constrainTop = (top: number) => Math.max(0, top);
+
+const resizeNorth = (currentSize, { left, height, width }, _containerWidth) => {
+  const top = currentSize.top - (height - currentSize.height);
+
+  return {
+    left,
+    width,
+    height: constrainHeight(top, currentSize.height, height),
+    top: constrainTop(top)
+  };
+};
+
+const resizeEast = (
+  currentSize,
+  { top, left, height, width },
+  containerWidth
+) => ({
+  top,
+  height,
+  width: constrainWidth(
+    currentSize.left,
+    currentSize.width,
+    width,
+    containerWidth
+  ),
+  left: constrainLeft(left)
+});
+
+const resizeWest = (currentSize, { top, height, width }, containerWidth) => {
+  const left = currentSize.left - (width - currentSize.width);
+
+  return {
+    height,
+    width:
+      left < 0
+        ? currentSize.width
+        : constrainWidth(
+            currentSize.left,
+            currentSize.width,
+            width,
+            containerWidth
+          ),
+    top: constrainTop(top),
+    left: constrainLeft(left)
+  };
+};
+
+const resizeSouth = (
+  currentSize,
+  { top, left, height, width },
+  containerWidth
+) => ({
+  width,
+  left,
+  height: constrainHeight(top, currentSize.height, height),
+  top: constrainTop(top)
+});
+
+const resizeNorthEast = (...args) =>
+  resizeNorth(args[0], resizeEast(...args), args[2]);
+const resizeNorthWest = (...args) =>
+  resizeNorth(args[0], resizeWest(...args), args[2]);
+const resizeSouthEast = (...args) =>
+  resizeSouth(args[0], resizeEast(...args), args[2]);
+const resizeSouthWest = (...args) =>
+  resizeSouth(args[0], resizeWest(...args), args[2]);
+
+const ordinalResizeHandlerMap = {
+  n: resizeNorth,
+  ne: resizeNorthEast,
+  e: resizeEast,
+  se: resizeSouthEast,
+  s: resizeSouth,
+  sw: resizeSouthWest,
+  w: resizeWest,
+  nw: resizeNorthWest
+};
+
+/**
+ * Helper for clamping width and position when resizing an item.
+ */
+export function resizeItemInDirection(
+  direction: ResizeHandleAxis,
+  currentSize: Position,
+  newSize: Position,
+  containerWidth: number
+): Position {
+  const ordinalHandler = ordinalResizeHandlerMap[direction];
+  // Shouldn't be possible given types; that said, don't fail hard
+  if (!ordinalHandler) return newSize;
+  return ordinalHandler(
+    currentSize,
+    { ...currentSize, ...newSize },
+    containerWidth
+  );
 }
 
 export function setTransform({ top, left, width, height }: Position): Object {

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -851,6 +851,36 @@ describe("Lifecycle tests", function () {
           });
         });
       });
+
+      describe("Resizing first row when containerPadding is disabled (#1929)", () => {
+        const rowHeight = 150;
+
+        it("resizes from s handle when containerPadding=[0, 0]", () => {
+          const wrapper = mount(
+            <ResizableLayout rowHeight={rowHeight} containerPadding={[0, 0]} />
+          );
+          const gridLayout = wrapper.find("ReactGridLayout");
+          const itemId = 0;
+          const gridItem0 = findGridItemByText(gridLayout, itemId);
+          const handleElement = findHandleForGridItem(gridItem0, "s");
+          const pos = getCurrentPosition(gridItem0);
+          const positionBeforeResize = getGridItemData(gridLayout, itemId);
+
+          // Resize down two columns
+          resizeTo(
+            handleElement,
+            false,
+            pos,
+            pos.left,
+            pos.top + rowHeight * 2
+          );
+          const positionAfterResize = getGridItemData(gridLayout, itemId);
+          expect(positionAfterResize).toEqual({
+            ...positionBeforeResize,
+            h: positionBeforeResize.h + 2
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This can happen if there is no container padding

Refactor and fix a similar bug with left = 0.

Fixes #1929, supersedes #1930
