### PR TITLE
GridItem: Fix cursor desync when used with React 18

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import { flushSync } from "react-dom";
 import PropTypes from "prop-types";
 import { DraggableCore } from "react-draggable";
 import { Resizable } from "react-resizable";
@@ -459,7 +460,9 @@ export default class GridItem extends React.Component<Props, State> {
     const pTop = parentRect.top / transformScale;
     newPosition.left = cLeft - pLeft + offsetParent.scrollLeft;
     newPosition.top = cTop - pTop + offsetParent.scrollTop;
-    this.setState({ dragging: newPosition });
+    flushSync(() => {
+      this.setState({ dragging: newPosition });
+    });
 
     // Call callback with this data
     const { x, y } = calcXY(
@@ -516,7 +519,9 @@ export default class GridItem extends React.Component<Props, State> {
     }
 
     const newPosition: PartialPosition = { top, left };
-    this.setState({ dragging: newPosition });
+    flushSync(() => {
+      this.setState({ dragging: newPosition });
+    });
 
     // Call callback with this data
     const { containerPadding } = this.props;
@@ -549,7 +554,9 @@ export default class GridItem extends React.Component<Props, State> {
     const { w, h, i, containerPadding } = this.props;
     const { left, top } = this.state.dragging;
     const newPosition: PartialPosition = { top, left };
-    this.setState({ dragging: null });
+    flushSync(() => {
+      this.setState({ dragging: null });
+    });
 
     const { x, y } = calcXY(
       this.getPositionParams(),
@@ -605,8 +612,10 @@ export default class GridItem extends React.Component<Props, State> {
         size,
         containerWidth
       );
-      this.setState({
-        resizing: handlerName === "onResizeStop" ? null : updatedSize
+      flushSync(() => {
+        this.setState({
+          resizing: handlerName === "onResizeStop" ? null : updatedSize
+        });
       });
     }
 


### PR DESCRIPTION
## Description

<!--
Don't leave this blank! Tell us what this PR is about, what it fixes, or what it adds.
-->

Hi! Love the library ❤️ 

This PR fixes desynchronisation of the cursor with the grid item by synchronously applying state changes.

I don't think you can reproduce this on your demo page since it runs with React 16, however you can reproduce the problem on something like https://play.grafana.org/. Repro steps:
- visit https://play.grafana.org/ in chrome
- open chrome dev tools -> performance tab -> set cpu slowdown to 6x
- click and drag in the bottom right of a panel to resize
- notice the large desync between panel and cursor position

I believe this is caused by the new automatic batching introduced in React 18. The current logic in `GridItem` relies on the props and state being up to date each time the handler (e.g. `onResizeHandler`) is called. With automatic batching, the state is less likely to be up to date. The result is this drift or desync between the cursor position and e.g. the drag handle position.

[The recommendation from the react team to opt out of automatic batching is to use `flushSync`](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#automatic-batching:~:text=To%20opt%2Dout%20of%20automatic%20batching%2C%20you%20can%20use%20flushSync%3A). Maybe there's some refactoring that can be done to avoid using `flushSync`, but I think that would require a maintainer weighing in and taking a look since I'm not so familiar with the codebase. 😅 

Another thing I'm not exactly sure about is when `flushSync` was exposed as part of the `react-dom` API. Using this may require a change to the minimum required version of `react-dom` specified in the peerDeps.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!--
Please use this format to link issue numbers: "Fixes #123"
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/react-grid-layout/react-grid-layout/issues/1975
Fixes https://github.com/react-grid-layout/react-grid-layout/issues/2003

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [x] 🙅 no documentation needed

<!--
  PRs with deleted sections will be marked invalid.

  Please do not commit built files (`/dist`) to pull requests. They are built only at release.
  PRs with changes to `/dist` or version increments in package.json will be rejected.
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
