### PR TITLE
Drag from outside positioning improvement

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -719,8 +719,10 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const gridRect = e.currentTarget.getBoundingClientRect(); // The grid's position in the viewport
 
     // Calculate the mouse position relative to the grid
-    const layerX = e.clientX - gridRect.left;
-    const layerY = e.clientY - gridRect.top;
+    const xUnitInPixels = width / cols;
+    const yUnitInPixels = rowHeight;
+    const layerX = Math.max(0, Math.round(e.clientX - gridRect.left - ((finalDroppingItem.w / 2) * xUnitInPixels)));
+    const layerY = Math.max(0, Math.round(e.clientY - gridRect.top - ((finalDroppingItem.h / 2) * yUnitInPixels)));
     const droppingPosition = {
       left: layerX / transformScale,
       top: layerY / transformScale,

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -380,9 +380,9 @@ describe("Lifecycle tests", function () {
         // We should have the position in our state.
         expect(gridLayout.state("droppingPosition")).toHaveProperty(
           "left",
-          200
+          147
         );
-        expect(gridLayout.state("droppingPosition")).toHaveProperty("top", 140);
+        expect(gridLayout.state("droppingPosition")).toHaveProperty("top", 125);
         // We should now have the placeholder element in our state.
         expect(gridLayout.state("droppingDOMNode")).toHaveProperty(
           "type",
@@ -401,8 +401,8 @@ describe("Lifecycle tests", function () {
           i: "__dropping-elem__",
           h: 1,
           w: 1,
-          x: 2,
-          y: 4,
+          x: 1,
+          y: 3,
           static: false,
           isDraggable: true
         });
@@ -412,7 +412,7 @@ describe("Lifecycle tests", function () {
 
         // State should change.
         expect(gridLayout.state("droppingPosition")).toHaveProperty("left", 0);
-        expect(gridLayout.state("droppingPosition")).toHaveProperty("top", 300);
+        expect(gridLayout.state("droppingPosition")).toHaveProperty("top", 285);
 
         layoutItem = gridLayout
           .state("layout")
@@ -446,8 +446,8 @@ describe("Lifecycle tests", function () {
           i: "__dropping-elem__",
           h: 2,
           w: 2,
-          x: 2,
-          y: 4,
+          x: 1,
+          y: 3,
           static: false,
           isDraggable: true
         });


### PR DESCRIPTION
## Description

This PR aims to improve the item positioning within `onDragOver` event handler called when dragging an item from outside the layout. 

The current experience treats your cursor as the top-left position of the grid item when dragging, meaning the placeholder is always below and to the right of your cursor, this often makes it feel like the library is not tracking your movement correctly, this is especially noticeable when dragging in larger items into the layout:


https://github.com/user-attachments/assets/b5c41304-7644-41dd-a67f-3d7602783dd6

This PR changes this behaviour, making the cursor more inline with the center of the placeholder:

https://github.com/user-attachments/assets/baa1bc2a-1a08-4881-9b1c-7391e0849c95



<!--
Don't leave this blank! Tell us what this PR is about, what it fixes, or what it adds.
-->

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!--
Please use this format to link issue numbers: "Fixes #123"
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [ ] 🙅 no documentation needed

<!--
  PRs with deleted sections will be marked invalid.

  Please do not commit built files (`/dist`) to pull requests. They are built only at release.
  PRs with changes to `/dist` or version increments in package.json will be rejected.
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
