### PR TITLE
Memoize bottom computation in compact

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -239,6 +239,8 @@ export function compact(
 ): Layout {
   // Statics go in the compareWith array right away so items flow around them.
   const compareWith = getStatics(layout);
+  // We keep track of the bottom position.
+  let b = bottom(compareWith);
   // We go through the items by row and column.
   const sorted = sortLayoutItems(layout, compactType);
   // Holding for new items.
@@ -249,7 +251,8 @@ export function compact(
 
     // Don't move static elements
     if (!l.static) {
-      l = compactItem(compareWith, l, compactType, cols, sorted, allowOverlap);
+      l = compactItem(compareWith, l, compactType, cols, sorted, allowOverlap, b);
+      b = Math.max(b, l.y + l.h);
 
       // Add to comparison array. We only collide with items before this one.
       // Statics are already in this array.
@@ -319,7 +322,8 @@ export function compactItem(
   compactType: CompactType,
   cols: number,
   fullLayout: Layout,
-  allowOverlap: ?boolean
+  allowOverlap: ?boolean,
+  b: number
 ): LayoutItem {
   const compactV = compactType === "vertical";
   const compactH = compactType === "horizontal";
@@ -327,7 +331,7 @@ export function compactItem(
     // Bottom 'y' possible is the bottom of the layout.
     // This allows you to do nice stuff like specify {y: Infinity}
     // This is here because the layout must be sorted in order to get the correct bottom `y`.
-    l.y = Math.min(bottom(compareWith), l.y);
+    l.y = Math.min(b, l.y);
     // Move the element up as far as it can go without colliding.
     while (l.y > 0 && !getFirstCollision(compareWith, l)) {
       l.y--;


### PR DESCRIPTION
## Description

Hi, thank you for the amazing library. We were having some performance issues with grids that have a lot of items (we started seeing really laggy behaviour at around 1200). A combination of a couple of fixes took care of almost all of our problems, namely:
1. The `requestAnimationFrame` fix in `react-draggable`. In our use case, we have clones of grid items which get removed when dragging starts for visual clarity. I've extended upon that with another PR https://github.com/react-grid-layout/react-draggable/pull/773. It would be great if `react-grid-layout` can eventually migrate to a newer `react-draggable` version.
1. The `flushSync` fix in this PR https://github.com/react-grid-layout/react-grid-layout/pull/2043.
1. The low-hanging fruit performance optimization that I'm suggesting here.

While 1 and 2 got us very far, this small memoization helps reduce the overhead of the `compact` function, which is executed every `onDrag` so tends to get expensive at this scale.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [x] 🙅 no documentation needed