### PR TITLE
fix(utils): fix case when margins are not consistent due to rounding

### DIFF
--- a/lib/calculateUtils.js
+++ b/lib/calculateUtils.js
@@ -86,6 +86,34 @@ export function calcGridItemPosition(
     out.left = Math.round((colWidth + margin[0]) * x + containerPadding[0]);
   }
 
+  if (!state || !(state.dragging || state.resizing)) {
+    if (Number.isFinite(w)) {
+      const marginRight =
+        Math.round((colWidth + margin[0]) * (x + w) + containerPadding[0]) -
+        out.left -
+        out.width;
+      const marginDeviation = Math.abs(marginRight - margin[0]);
+      if (marginRight > margin[0]) {
+        out.width += marginDeviation;
+      } else if (marginRight < margin[0]) {
+        out.width -= marginDeviation;
+      }
+    }
+
+    if (Number.isFinite(h)) {
+      const marginBottom =
+        Math.round((rowHeight + margin[1]) * (y + h) + containerPadding[1]) -
+        out.top -
+        out.height;
+      const marginDeviation = Math.abs(marginBottom - margin[1]);
+      if (marginBottom > margin[1]) {
+        out.height += marginDeviation;
+      } else if (marginBottom < margin[1]) {
+        out.height -= marginDeviation;
+      }
+    }
+  }
+
   return out;
 }
 


### PR DESCRIPTION
## Description

Currently margins are not consistent. For example if we set margins to `[1,1]` it sometimes makes it 2px or 0px (see screenshots). This PR introduces margins check and fix.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents


## Mobile & Desktop Screenshots/Recordings
### Before fix
![Screenshot from 2025-05-19 15-56-41](https://github.com/user-attachments/assets/b2c740c5-46a2-41bb-9efd-08240b0c05a6)
![Screenshot from 2025-05-19 15-54-42](https://github.com/user-attachments/assets/244a5e02-4980-48d8-8548-177d7521ceaa)

### After fix
![Screenshot from 2025-05-19 15-58-22](https://github.com/user-attachments/assets/81652bbd-246d-4e50-b21b-fb4d1dc3f7b0)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [x] 🙅 no documentation needed
