### PR TITLE
fix(css): remove user-select:none from grid items to restore auto-scroll

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,7 +5,6 @@
 .react-grid-item {
   transition: all 200ms ease;
   transition-property: left, top, width, height;
-  user-select: none;
 }
 .react-grid-item img {
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Removes unintentional `user-select: none` from `.react-grid-item` that was preventing auto-scroll during drag

## Details
This CSS property was accidentally added in the React 18 upgrade commit (1c6b2eb8). It was causing browsers to not auto-scroll when dragging items near the edge of a scrollable container.

The placeholder (`.react-grid-placeholder`) and images (`.react-grid-item img`) retain `user-select: none` as intended.

Fixes #2187

## Test plan
- [x] Verify auto-scrolling works when dragging items near container edges
- [x] Verify text selection during drag is still prevented by react-draggable's internal handling