### PR TITLE
chore(ci): improve changelog action for better release notes

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,31 +1,96 @@
 {
   "categories": [
     {
-      "title": "## 🚀 Features",
-      "labels": ["feature"]
+      "title": "## 💥 Breaking Changes",
+      "labels": ["breaking-change", "Semver-Major"]
     },
     {
-      "title": "## 🐛 Fixes",
-      "labels": ["fix"]
+      "title": "## ✨ New Features",
+      "labels": ["enhancement", "feature", "Semver-Minor"]
+    },
+    {
+      "title": "## 🐛 Bug Fixes",
+      "labels": ["bug", "fix"]
+    },
+    {
+      "title": "## ⚡ Performance",
+      "labels": ["performance"]
+    },
+    {
+      "title": "## 📚 Documentation",
+      "labels": ["documentation"]
     },
     {
       "title": "## 🧪 Tests",
-      "labels": ["test"]
+      "labels": ["tests", "test"]
+    },
+    {
+      "title": "## 🔧 Internal Changes",
+      "labels": ["infrastructure", "core", "deps", "dependencies", "chore"]
     }
   ],
-  "ignore_labels": ["ignore_changelog"],
+  "ignore_labels": [
+    "ignore_changelog",
+    "stale",
+    "duplicate",
+    "invalid",
+    "wontfix",
+    "WIP - Don't Merge"
+  ],
   "sort": "ASC",
-  "template": "${{CHANGELOG}}\n\n<details open>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
-  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
-  "empty_template": "- no changes",
+  "template": "${{CHANGELOG}}${{UNCATEGORIZED}}",
+  "pr_template": "- **${{TITLE}}** - [#${{NUMBER}}](${{URL}}) by [@${{AUTHOR}}](https://github.com/${{AUTHOR}})",
+  "empty_template": "No notable changes in this release.",
   "label_extractor": [
     {
-      "pattern": "\\[Issue\\]",
+      "pattern": "^fix(\\(.+\\))?:",
       "on_property": "title",
-      "method": "match"
+      "method": "match",
+      "target": "bug"
+    },
+    {
+      "pattern": "^feat(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "enhancement"
+    },
+    {
+      "pattern": "^docs(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "documentation"
+    },
+    {
+      "pattern": "^chore(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "chore"
+    },
+    {
+      "pattern": "^test(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "tests"
+    },
+    {
+      "pattern": "^perf(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "performance"
+    },
+    {
+      "pattern": "^refactor(\\(.+\\))?:",
+      "on_property": "title",
+      "method": "match",
+      "target": "infrastructure"
     }
   ],
-  "transformers": [],
+  "transformers": [
+    {
+      "pattern": "^(fix|feat|docs|chore|test|perf|refactor)(\\(.+\\))?:\\s*",
+      "target": ""
+    }
+  ],
   "max_tags_to_fetch": 200,
   "max_pull_requests": 200,
   "max_back_track_time_days": 365,

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,18 +2,44 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-      - dependencies
+      - ignore_changelog
+      - stale
+      - duplicate
+      - invalid
+      - wontfix
     authors:
       - octocat
   categories:
-    - title: Breaking Changes 🛠
+    - title: 💥 Breaking Changes
       labels:
         - Semver-Major
         - breaking-change
-    - title: Exciting New Features 🎉
+    - title: ✨ New Features
       labels:
         - Semver-Minor
         - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: ⚡ Performance
+      labels:
+        - performance
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧪 Tests
+      labels:
+        - tests
+        - test
+    - title: 🔧 Internal Changes
+      labels:
+        - infrastructure
+        - core
+        - deps
+        - dependencies
+        - chore
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,21 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v2
+        uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ".github/changelog-configuration.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{steps.github_release.outputs.changelog}}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.github_release.outputs.changelog }}
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Improves the automatic changelog generation for releases to produce more useful and organized release notes.

### Changes

**`.github/changelog-configuration.json`:**
- Added more categories: Breaking Changes, New Features, Bug Fixes, Performance, Documentation, Tests, Internal Changes
- Better PR template with bold titles, clickable links, and author attribution
- Label extractors for conventional commit prefixes (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, `perf:`, `refactor:`)
- Transformers to strip commit prefixes from titles for cleaner output
- Expanded ignore list for stale/invalid/duplicate PRs

**`.github/release.yml`:**
- Consistent categories with emojis matching the changelog config
- Added Performance, Documentation, and Tests sections

**`.github/workflows/changelog.yml`:**
- Updated to `actions/checkout@v4`
- Updated to `mikepenz/release-changelog-builder-action@v5`
- Replaced deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Added `fetch-depth: 0` for full git history (needed for changelog generation)

### New Labels Created

Also created missing labels in the repo to support categorization:
- `fix`, `feature`, `performance`, `breaking-change`, `chore`, `ignore_changelog`

## Test Plan

- [ ] Next release will use these configurations automatically
- [ ] PRs can be categorized by either labels or conventional commit prefixes in titles