### PR TITLE
fix: update husky to v9 configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn lint-staged
 yarn typecheck
 make test

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "build-example": "make build-example",
     "view-example": "make view-example",
     "dev": "make dev",
+    "prepare": "husky",
     "prepublishOnly": "make build",
     "validate": "npm ls",
     "fmt": "prettier --write .",


### PR DESCRIPTION
## Summary
- Remove v7 sourcing from pre-commit hook (husky v9 no longer uses the `_/` directory pattern)
- Add `prepare` script to run `husky` for proper initialization
- Pre-commit hooks now run correctly on commit

## Background
The pre-commit hooks weren't running because:
1. `core.hooksPath` was pointing to `.husky/_/` (v7 pattern) but hooks were in `.husky/`
2. husky v9 was installed but using v7 configuration structure
3. Missing `prepare` script to initialize husky

## Test plan
- [x] Verified hooks run on commit by committing a file with bad formatting
- [x] lint-staged ran and auto-fixed the formatting
- [x] typecheck ran
- [x] tests ran (all 508 passed)