### PR TITLE
fix: prevent infinite loop when dragging from outside then leaving (#2210)

### DIFF
--- a/.claude/skills/fix-issue.md
+++ b/.claude/skills/fix-issue.md
@@ -57,6 +57,7 @@ You are an expert at fixing bugs in the react-grid-layout codebase. Follow this 
    - Include a comment referencing the issue number: `// #<issue-number>`
 
 2. **Verify the test fails:**
+
    ```bash
    NODE_ENV=test npx jest --testPathPatterns="<test-file>"
    ```


### PR DESCRIPTION
## Summary

Fixes #2210

When an item is dragged from outside into the grid and then moved outside without releasing the mouse button, an infinite loop would occur causing the "Maximum update depth exceeded" React warning.

### Root cause

The GridItem's constraint context (`constraintContext`) included `layout` in its memoization dependencies. This meant:

1. When dragging from outside, the dropping item's GridItem is created
2. Its `onDrag`/`onDragStart` callbacks depend on `constraintContext`  
3. When the user drags outside (triggering `dragLeave`), `removeDroppingPlaceholder` updates the layout
4. Layout change → `constraintContext` recreated → callbacks recreated
5. The dropping item's `useEffect` (which depends on `onDrag`/`onDragStart`) re-runs
6. It calls the new `onDrag` → which updates layout again
7. Infinite loop!

### The fix

Apply the same pattern used in GridLayout.tsx (#2204) to GridItem.tsx:

- Add a `layoutRef` in GridItem to track the current layout without triggering re-renders
- Remove `layout` from `constraintContext`'s memoization dependencies
- Create a `getConstraintContext()` getter function that retrieves the current layout from the ref when called
- Update all drag/resize callbacks to use `getConstraintContext()` instead of the memoized `constraintContext`

## Test plan

- [x] Added test that simulates drag-in-then-drag-out scenario
- [x] Test verifies no "Maximum update depth exceeded" errors occur
- [x] Test verifies onDrag isn't called excessively (which would indicate an infinite loop)
- [x] All existing tests pass
- [x] Lint passes