### PR TITLE
fix: use dropConfig.onDragOver when provided (#2212)

### DIFF
--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -370,7 +370,11 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     handles: resizeHandles,
     handleComponent: resizeHandle
   } = resizeConfig;
-  const { enabled: isDroppable, defaultItem: defaultDropItem } = dropConfig;
+  const {
+    enabled: isDroppable,
+    defaultItem: defaultDropItem,
+    onDragOver: dropConfigOnDragOver
+  } = dropConfig;
 
   // Get compactor (use provided or get from type)
   const compactor = compactorProp ?? getCompactor("vertical");
@@ -796,8 +800,11 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
         return false;
       }
 
-      // Extract dragOffsetX from result, or use empty object if void/undefined
-      const rawResult = onDropDragOverProp(e);
+      // Use dropConfig.onDragOver if provided, otherwise fall back to onDropDragOver prop (#2212)
+      // dropConfig.onDragOver uses native DragEvent, onDropDragOver uses React's DragEvent
+      const rawResult = dropConfigOnDragOver
+        ? dropConfigOnDragOver(e.nativeEvent as DragEvent)
+        : onDropDragOverProp(e);
       if (rawResult === false) {
         if (droppingDOMNode) {
           removeDroppingPlaceholder();
@@ -892,6 +899,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       droppingDOMNode,
       droppingPosition,
       droppingItem,
+      dropConfigOnDragOver,
       onDropDragOverProp,
       removeDroppingPlaceholder,
       transformScale,


### PR DESCRIPTION
## Summary

Fixes #2212

The `DropConfig` type specifies an `onDragOver` method but GridLayout was ignoring it and only using the legacy `onDropDragOver` prop.

### Root cause

In `GridLayout.tsx`, the `onDragOver` handler only checked for the legacy `onDropDragOver` prop but never looked at `dropConfig.onDragOver`, even though the type definition includes this callback.

### The fix

Extract `onDragOver` from `dropConfig` and use it when provided, falling back to the legacy `onDropDragOver` prop for backwards compatibility. Note that `dropConfig.onDragOver` receives native `DragEvent` while the legacy prop receives React's `SyntheticEvent`.

## Test plan

- [x] Added test that fails without fix
- [x] Test passes with fix
- [x] All existing tests pass (518 passed)