### PR TITLE
fix: use custom compactor.compact() method when provided (#2213)

### DIFF
--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -1962,4 +1962,40 @@ describe("Lifecycle tests", function () {
       expect(styleAfter).not.toEqual(styleBefore);
     });
   });
+
+  // #2213 - Custom compactors should have their methods called
+  describe("Custom Compactors", function () {
+    it("calls custom compactor.compact() when layout changes (v2 API) (#2213)", function () {
+      const customCompact = jest.fn(layout => layout);
+      const customOnMove = jest.fn((layout, _item, _x, _y, _cols) => layout);
+
+      const customCompactor = {
+        type: "vertical",
+        allowOverlap: false,
+        preventCollision: false,
+        compact: customCompact,
+        onMove: customOnMove
+      };
+
+      render(
+        <GridLayoutV2
+          className="layout"
+          gridConfig={{ cols: 12, rowHeight: 30 }}
+          width={1200}
+          layout={[
+            { i: "a", x: 0, y: 0, w: 2, h: 2 },
+            { i: "b", x: 2, y: 0, w: 2, h: 2 }
+          ]}
+          compactor={customCompactor}
+        >
+          <div key="a">a</div>
+          <div key="b">b</div>
+        </GridLayoutV2>
+      );
+
+      // The custom compactor's compact method should have been called
+      // during initial layout processing
+      expect(customCompact).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2213

The `Compactor` interface defines `compact()` and `onMove()` methods that allow users to implement custom compaction algorithms. However, `GridLayout` was ignoring these methods and only using the legacy `compact()` function from `compact-compat.js`. This meant custom compactors like the one in the issue would never have their `compact()` method called.

### Root cause

`GridLayout.tsx` was:
1. Extracting only properties from the compactor (`type`, `allowOverlap`, `preventCollision`)
2. Passing these to the legacy `compact()` function
3. Never calling `compactor.compact()` or `compactor.onMove()`

### The fix

Replace all calls to the legacy `compact()` function with calls to `compactor.compact()`:
- `synchronizeLayoutWithChildren` now takes a `Compactor` instead of `compactType`/`allowOverlap`
- All `setLayout` calls that used `compact()` now use `compactor.compact()`
- Updated `useCallback` dependency arrays accordingly

The built-in compactors (like `verticalCompactor`, `horizontalCompactor`) already implement `allowOverlap` behavior internally via their `compact()` method, so the allowOverlap check before calling compact can be removed - the compactor handles it.

## Test plan

- [x] Added test that fails without fix (custom `compact()` never called)
- [x] Test passes with fix
- [x] All existing tests pass (519 passed)