### PR TITLE
fix: enable PositionStrategy and DragConfig.threshold extension points (#2217)

### DIFF
--- a/src/legacy/ReactGridLayout.tsx
+++ b/src/legacy/ReactGridLayout.tsx
@@ -200,7 +200,10 @@ function ReactGridLayout(props: LegacyReactGridLayoutProps) {
     enabled: isDraggable,
     bounded: isBounded,
     handle: draggableHandle,
-    cancel: draggableCancel
+    cancel: draggableCancel,
+    // Set threshold to 0 for backwards compatibility with v1 API
+    // v2 API defaults to 3px threshold (fixes #1341, #1401)
+    threshold: 0
   };
 
   const resizeConfig: Partial<ResizeConfig> = {

--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -362,7 +362,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     enabled: isDraggable,
     bounded: isBounded,
     handle: draggableHandle,
-    cancel: draggableCancel
+    cancel: draggableCancel,
+    threshold: dragThreshold
   } = dragConfig;
   const {
     enabled: isResizable,
@@ -984,6 +985,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
           useCSSTransforms={useCSSTransforms && mounted}
           usePercentages={!mounted}
           transformScale={transformScale}
+          positionStrategy={positionStrategy}
+          dragThreshold={dragThreshold}
           w={l.w}
           h={l.h}
           x={l.x}
@@ -1027,6 +1030,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       useCSSTransforms,
       mounted,
       transformScale,
+      positionStrategy,
+      dragThreshold,
       droppingPosition,
       resizeHandles,
       resizeHandle,

--- a/test/spec/typescript-components-test.tsx
+++ b/test/spec/typescript-components-test.tsx
@@ -255,6 +255,8 @@ describe("TypeScript Components", () => {
           width={1200}
           onDragStart={onDragStart}
           layout={[{ i: "a", x: 0, y: 0, w: 2, h: 2 }]}
+          // Set threshold to 0 to test immediate callback (v2 default is 3px)
+          dragConfig={{ threshold: 0 }}
         >
           <div key="a">a</div>
         </GridLayout>


### PR DESCRIPTION
## Summary

Two extension points were defined in the v2 API but never actually used - similar to the compactor issue in #2213. This PR enables them properly:

### 1. PositionStrategy (`calcStyle` and `calcDragPosition`)
- `calcStyle(pos)` - Custom method for calculating item CSS styles
- `calcDragPosition(clientX, clientY, offsetX, offsetY)` - Custom method for calculating drag position

Before: Only `type` and `scale` properties were extracted from the position strategy. Custom implementations of `calcStyle()` and `calcDragPosition()` were ignored.

After: Custom position strategies can now override both positioning and drag position calculation.

### 2. DragConfig.threshold
- `threshold` - Number of pixels mouse must move before drag starts (default: 3)

Before: The `threshold` property was defined in `DragConfig` with a default of 3px but was never extracted or passed to GridItem.

After: The threshold is now properly implemented - drag callbacks won't fire until the mouse moves the threshold distance from the initial mousedown position.

### Backwards Compatibility
- **Legacy API**: Sets `threshold: 0` for immediate drag callbacks (same as v1 behavior)
- **v2 API**: Defaults to `threshold: 3` (fixes #1341, #1401 - prevents accidental drags)

## Changes

| File | Description |
|------|-------------|
| `src/react/components/GridLayout.tsx` | Extract `dragThreshold`, pass `positionStrategy` to GridItem |
| `src/react/components/GridItem.tsx` | Use `positionStrategy.calcStyle()`, implement drag threshold |
| `src/legacy/ReactGridLayout.tsx` | Set `threshold: 0` for backwards compatibility |
| `test/spec/lifecycle-test.js` | Add tests for custom PositionStrategy and DragConfig.threshold |
| `test/spec/typescript-components-test.tsx` | Update test to set threshold for immediate callback |

## Test plan

- [x] Test that custom `positionStrategy.calcStyle()` is called for item positioning
- [x] Test that custom `positionStrategy.calcDragPosition()` is called during drag
- [x] Test that drag doesn't start until mouse moves threshold pixels
- [x] Test that default threshold of 3px is used when not specified
- [x] All existing tests pass
- [x] Legacy API maintains backwards compatibility (threshold=0)