### PR TITLE
fix: west resize not persisting final size due to React batching

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: code-reviewer
+description: Expert code review specialist for quality, security, and maintainability. Use PROACTIVELY after writing or modifying code to ensure high development standards.
+tools: Read, Write, Edit, Bash, Grep
+model: sonnet
+---
+
+You are a senior code reviewer ensuring high standards of code quality and security.
+
+When invoked:
+
+1. Run git diff to see recent changes
+2. Focus on modified files
+3. Begin review immediately
+
+Review checklist:
+
+- Code is simple and readable
+- Functions and variables are well-named
+- No duplicated code
+- Proper error handling
+- No exposed secrets or API keys
+- Input validation implemented
+- Good test coverage
+- Performance considerations addressed
+
+Provide feedback organized by priority:
+
+- Critical issues (must fix)
+- Warnings (should fix)
+- Suggestions (consider improving)
+
+Include specific examples of how to fix issues.


### PR DESCRIPTION
## Summary
- Fix `onResizeStop` not persisting the final resize size due to React state batching
- Store resize position during `onResize` and use it in `onResizeStop` instead of stale data from react-resizable
- Re-apply resize logic in `onResizeStop` handler to ensure final layout is correct

## Problem
When resizing from west handles (W, NW, SW), the resize would appear to work during the drag, but could snap back to incorrect values on mouse release. This was caused by:

1. `react-resizable`'s `onResizeStop` reports the DOM element's current size, but React hasn't re-rendered yet (state updates are batched), so it reports stale size data
2. `GridLayout.onResizeStop` was reading from `layoutRef.current` which still contained the pre-resize layout

## Solution
- **GridItem**: Store resize position during `onResize` in a ref, use it in `onResizeStop` instead of `data.size`
- **GridLayout**: Re-apply the same resize logic in `onResizeStop` as `onResize` (including collision checking for `preventCollision` mode)

## Test plan
- [x] Added regression test for west resize with item at y=1
- [x] All existing tests pass
- [x] `preventCollision` tests still pass

Note: This is related to but does not fully address #2109. The original issue describes position shifting *during* resize, which may be a separate bug to investigate.