### PR TITLE
fix: prevent drop placeholder from persisting after dragging outside grid

### DIFF
--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -781,6 +781,11 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       cols
     );
 
+    // Eagerly update layoutRef so that any onDrag callback fired in the same
+    // event loop (before React re-renders) will read the cleaned layout and
+    // bail out via its getLayoutItem() null check, preventing it from
+    // re-setting activeDrag after we clear it below.
+    layoutRef.current = newLayout;
     setLayout(newLayout);
     setDroppingDOMNode(null);
     setActiveDrag(null);


### PR DESCRIPTION
## Description

This PR fixes a race condition where the drop placeholder remains visible after dragging an external item outside the grid boundary.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to #2239 — both are race conditions between drag event handlers and React's batched state updates on `layoutRef.current`.

## Root Cause

When an external item is dragged over the grid and then out, `removeDroppingPlaceholder()` fires correctly (via `dragEnterCounter` reaching 0). However, the placeholder can reappear due to a race with the `onDrag` callback:

1. `removeDroppingPlaceholder()` queues state updates: `setLayout(filtered)`, `setActiveDrag(null)`, `setDroppingDOMNode(null)`
2. Before React re-renders, `onDrag` fires (triggered by the dropping GridItem's `droppingPosition` effect) and reads `layoutRef.current` — which still contains the dropping item because the ref is only synced during render (`layoutRef.current = layout`).
3. `onDrag` finds the dropping item via `getLayoutItem()`, proceeds, and calls `setActiveDrag(placeholder)` — **overriding** the `null` from step 1.
4. React batches all updates. Final state: `activeDrag = placeholder` (from step 3), `droppingDOMNode = null` (from step 1). `renderPlaceholder()` sees `activeDrag !== null` and renders a visible placeholder that nothing will clean up.

Debug logging confirmed the exact sequence:

```
[removeDroppingPlaceholder] hasDroppingItem= true counter= 0
[onDrag] DROPPING ITEM — will setActiveDrag. droppingDOMNode= true   ← fires AFTER cleanup, stale layoutRef
[renderPlaceholder] rendering for DROPPING ITEM, droppingDOMNode= false  ← placeholder re-appears
```

## Fix

Eagerly update `layoutRef.current` in `removeDroppingPlaceholder` before the queued `setLayout` call:

```typescript
layoutRef.current = newLayout;
setLayout(newLayout);
```

This ensures any `onDrag` invocation in the same event loop reads the cleaned layout. `getLayoutItem()` returns `null` for the dropping item, `onDrag` bails out, and the `setActiveDrag` override never happens.

The eager ref update is safe because:
- `layoutRef.current = layout` already runs at the top of each render, so the next render will set the same value
- This pattern is consistent with how `layoutRef` is designed — a synchronous escape hatch for callbacks that need the latest layout without depending on React's render cycle

## Mobile & Desktop Screenshots/Recordings

N/A — no visual changes beyond the bug fix.

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

The race condition depends on React batching timing between DOM event handlers, which is difficult to reproduce reliably in unit tests. All 517 existing tests pass.

## Added to documentation?

- [x] 🙅 no documentation needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a race condition in grid layout drag operations that could cause the layout to become out of sync with drag callbacks, resulting in more reliable and consistent grid behavior during item dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->