### PR TITLE
fix(2254): Optional debouncing of width updates for responsive layouts

### DIFF
--- a/examples/util/vars.js
+++ b/examples/util/vars.js
@@ -193,4 +193,13 @@ module.exports = [
         "top-half positioning, and snap-to-grid."
     ]
   },
+    {
+    title: "Debounced Layout Change",
+    source: "debounced-layout-change",
+    paragraphs: [
+      "This demonstrates how to debounce triggering <code>onLayoutChange</code> event on browser width change.",
+      "Dragging and resizing items within the layout will trigger the <code>onLayoutChange</code> event immediately, " +
+      "but resizing the browser window will delay triggering <code>onLayoutChange</code> event by a specified timeout, in this case 500ms."
+    ]
+  },
 ];

--- a/src/react/components/WidthProvider.tsx
+++ b/src/react/components/WidthProvider.tsx
@@ -15,6 +15,8 @@ import clsx from "clsx";
 export interface WidthProviderProps {
   /** If true, will not render children until mounted */
   measureBeforeMount?: boolean;
+  /** Timeout in milliseconds to delay the resizing of grid-items */
+  debounceTimeout?: number;
   /** Additional class name */
   className?: string;
   /** Additional styles */
@@ -58,12 +60,14 @@ export function WidthProvider<P extends { width: number }>(
   ComposedComponent: ComponentType<P>
 ): ComponentType<WithWidthProps<P>> {
   function WidthProviderWrapper(props: WithWidthProps<P>) {
-    const { measureBeforeMount = false, className, style, ...rest } = props;
+    const { measureBeforeMount = false, debounceTimeout = 0,className, style, ...rest } = props;
 
     const [width, setWidth] = useState(1280);
     const [mounted, setMounted] = useState(false);
     const elementRef = useRef<HTMLDivElement>(null);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
+    const rafIdRef = useRef<number | null>(null);
+    const debounceTimeoutIdRef = useRef<number | null>(null);
 
     // Set mounted state on first render
     useEffect(() => {
@@ -76,35 +80,63 @@ export function WidthProvider<P extends { width: number }>(
       const node = elementRef.current;
       if (!(node instanceof HTMLElement)) return;
 
-      let rafId: number | null = null;
+      resizeObserverRef.current = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (entry) {
+          // Use contentRect.width for consistent measurements
+          const newWidth = entry.contentRect.width;
 
-      const observer = new ResizeObserver(entries => {
-        if (entries[0]) {
-          const newWidth = entries[0].contentRect.width;
-
-          // Defer state update to next paint cycle to avoid
-          // "ResizeObserver loop completed with undelivered notifications" error (#1959)
-          if (rafId !== null) {
-            cancelAnimationFrame(rafId);
+          // Clear any existing debounce timeout
+          if (debounceTimeoutIdRef.current !== null) {
+            clearTimeout(debounceTimeoutIdRef.current);
           }
-          rafId = requestAnimationFrame(() => {
-            setWidth(newWidth);
-            rafId = null;
-          });
+
+          // Clear any existing RAF
+          if (rafIdRef.current !== null) {
+            cancelAnimationFrame(rafIdRef.current);
+          }
+
+          // No debounce, update immediately on next RAF and return
+          if (debounceTimeout <= 0) {
+            // Defer state update to next paint cycle to avoid
+            // "ResizeObserver loop completed with undelivered notifications" error (#1959)
+            rafIdRef.current = requestAnimationFrame(() => {
+              setWidth(newWidth);
+              rafIdRef.current = null;
+            });
+            return;
+          }
+
+          // Apply debounce before RAF
+          debounceTimeoutIdRef.current = window.setTimeout(() => {
+            // Defer state update to next paint cycle to avoid
+            // "ResizeObserver loop completed with undelivered notifications" error (#1959)
+            rafIdRef.current = requestAnimationFrame(() => {
+              setWidth(newWidth);
+              rafIdRef.current = null;
+              debounceTimeoutIdRef.current = null;
+            });
+          }, debounceTimeout);
         }
       });
 
-      observer.observe(node);
-      resizeObserverRef.current = observer;
+      resizeObserverRef.current.observe(node);
 
       return () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
+        // Cancel any pending debounce timeout
+        if (debounceTimeoutIdRef.current !== null) {
+          clearTimeout(debounceTimeoutIdRef.current);
         }
-        observer.unobserve(node);
-        observer.disconnect();
+        // Cancel any pending RAF to prevent state updates on unmounted component
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+        }
+        if (resizeObserverRef.current !== null) {
+          resizeObserverRef.current.unobserve(node);
+          resizeObserverRef.current.disconnect();
+        }
       };
-    }, [mounted]);
+    }, [mounted, debounceTimeout]);
 
     // If measureBeforeMount is true and not yet mounted, render placeholder
     if (measureBeforeMount && !mounted) {

--- a/src/react/hooks/useContainerWidth.ts
+++ b/src/react/hooks/useContainerWidth.ts
@@ -83,6 +83,8 @@ export function useContainerWidth(
   const [mounted, setMounted] = useState(!measureBeforeMount);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const debounceTimeoutIdRef = useRef<number | null>(null);
 
   const measureWidth = useCallback(() => {
     const node = containerRef.current;
@@ -104,9 +106,7 @@ export function useContainerWidth(
 
     // Set up ResizeObserver
     if (typeof ResizeObserver !== "undefined") {
-      let rafId: number | null = null;
-      let debounceTimeoutId: number | null = null;
-
+      
       observerRef.current = new ResizeObserver(entries => {
         const entry = entries[0];
         if (entry) {
@@ -114,64 +114,57 @@ export function useContainerWidth(
           const newWidth = entry.contentRect.width;
 
           // Clear any existing debounce timeout
-          if (debounceTimeoutId !== null) {
-            clearTimeout(debounceTimeoutId);
+          if (debounceTimeoutIdRef.current !== null) {
+            clearTimeout(debounceTimeoutIdRef.current);
           }
 
           // Clear any existing RAF
-          if (rafId !== null) {
-            cancelAnimationFrame(rafId);
+          if (rafIdRef.current !== null) {
+            cancelAnimationFrame(rafIdRef.current);
           }
 
           // No debounce, update immediately on next RAF and return
           if (debounceTimeout <= 0) {
             // Defer state update to next paint cycle to avoid
             // "ResizeObserver loop completed with undelivered notifications" error (#1959)
-            rafId = requestAnimationFrame(() => {
+            rafIdRef.current = requestAnimationFrame(() => {
               setWidth(newWidth);
-              rafId = null;
+              rafIdRef.current = null;
             });
             return;
           }
 
           // Apply debounce before RAF
-          debounceTimeoutId = window.setTimeout(() => {
+          debounceTimeoutIdRef.current = window.setTimeout(() => {
             // Defer state update to next paint cycle to avoid
             // "ResizeObserver loop completed with undelivered notifications" error (#1959)
-            rafId = requestAnimationFrame(() => {
+            rafIdRef.current = requestAnimationFrame(() => {
               setWidth(newWidth);
-              rafId = null;
-              debounceTimeoutId = null;
+              rafIdRef.current = null;
+              debounceTimeoutIdRef.current = null;
             });
           }, debounceTimeout);
         }
       });
 
       observerRef.current.observe(node);
-
-      return () => {
-        // Cancel any pending debounce timeout
-        if (debounceTimeoutId !== null) {
-          clearTimeout(debounceTimeoutId);
-        }
-        // Cancel any pending RAF to prevent state updates on unmounted component
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-        }
-        if (observerRef.current) {
-          observerRef.current.disconnect();
-          observerRef.current = null;
-        }
-      };
     }
 
     return () => {
-      if (observerRef.current) {
+      // Cancel any pending debounce timeout
+      if (debounceTimeoutIdRef.current !== null) {
+        clearTimeout(debounceTimeoutIdRef.current);
+      }
+      // Cancel any pending RAF to prevent state updates on unmounted component
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      if (observerRef.current !== null) {
         observerRef.current.disconnect();
         observerRef.current = null;
       }
     };
-  }, [measureWidth]);
+  }, [measureWidth, debounceTimeout]);
 
   return {
     width,

--- a/src/react/hooks/useContainerWidth.ts
+++ b/src/react/hooks/useContainerWidth.ts
@@ -25,6 +25,12 @@ export interface UseContainerWidthOptions {
    * Defaults to 1280.
    */
   initialWidth?: number;
+
+  /**
+   * Timeout in milliseconds to delay the resizing of grid-items
+   * Defaults to 0
+   */
+  debounceTimeout?: number;
 }
 
 export interface UseContainerWidthResult {
@@ -71,7 +77,7 @@ export interface UseContainerWidthResult {
 export function useContainerWidth(
   options: UseContainerWidthOptions = {}
 ): UseContainerWidthResult {
-  const { measureBeforeMount = false, initialWidth = 1280 } = options;
+  const { measureBeforeMount = false, initialWidth = 1280, debounceTimeout = 0 } = options;
 
   const [width, setWidth] = useState(initialWidth);
   const [mounted, setMounted] = useState(!measureBeforeMount);
@@ -99,6 +105,7 @@ export function useContainerWidth(
     // Set up ResizeObserver
     if (typeof ResizeObserver !== "undefined") {
       let rafId: number | null = null;
+      let debounceTimeoutId: number | null = null;
 
       observerRef.current = new ResizeObserver(entries => {
         const entry = entries[0];
@@ -106,21 +113,47 @@ export function useContainerWidth(
           // Use contentRect.width for consistent measurements
           const newWidth = entry.contentRect.width;
 
-          // Defer state update to next paint cycle to avoid
-          // "ResizeObserver loop completed with undelivered notifications" error (#1959)
+          // Clear any existing debounce timeout
+          if (debounceTimeoutId !== null) {
+            clearTimeout(debounceTimeoutId);
+          }
+
+          // Clear any existing RAF
           if (rafId !== null) {
             cancelAnimationFrame(rafId);
           }
-          rafId = requestAnimationFrame(() => {
-            setWidth(newWidth);
-            rafId = null;
-          });
+
+          // No debounce, update immediately on next RAF and return
+          if (debounceTimeout <= 0) {
+            // Defer state update to next paint cycle to avoid
+            // "ResizeObserver loop completed with undelivered notifications" error (#1959)
+            rafId = requestAnimationFrame(() => {
+              setWidth(newWidth);
+              rafId = null;
+            });
+            return;
+          }
+
+          // Apply debounce before RAF
+          debounceTimeoutId = window.setTimeout(() => {
+            // Defer state update to next paint cycle to avoid
+            // "ResizeObserver loop completed with undelivered notifications" error (#1959)
+            rafId = requestAnimationFrame(() => {
+              setWidth(newWidth);
+              rafId = null;
+              debounceTimeoutId = null;
+            });
+          }, debounceTimeout);
         }
       });
 
       observerRef.current.observe(node);
 
       return () => {
+        // Cancel any pending debounce timeout
+        if (debounceTimeoutId !== null) {
+          clearTimeout(debounceTimeoutId);
+        }
         // Cancel any pending RAF to prevent state updates on unmounted component
         if (rafId !== null) {
           cancelAnimationFrame(rafId);

--- a/test/examples/22-debounced-layout-change.jsx
+++ b/test/examples/22-debounced-layout-change.jsx
@@ -3,6 +3,7 @@ import _ from "lodash";
 import Responsive from '../../src/legacy/ResponsiveReactGridLayout';
 import WidthProvider from '../../src/legacy/WidthProvider';
 
+const debouncedTimeoutMs = 500;
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 export default class DebouncedLayout extends React.Component {
@@ -15,9 +16,10 @@ export default class DebouncedLayout extends React.Component {
 
   state = {
     currentBreakpoint: "lg",
-    debouncedTimeout: 500,
+    debouncedTimeout: debouncedTimeoutMs,
     mounted: false,
-    layouts: { lg: generateLayout(['se']) }
+    layouts: { lg: generateLayout(['se']) },
+    resizeHandles: ['se']
   };
 
   componentDidMount() {
@@ -49,8 +51,8 @@ export default class DebouncedLayout extends React.Component {
     });
   };
 
-  onDebouncedTimoutChange = () => {
-    const debouncedTimeout = this.state.debouncedTimeout === 0 ? 500 : 0;
+  onDebouncedTimeoutChange = () => {
+    const debouncedTimeout = this.state.debouncedTimeout === 0 ? debouncedTimeoutMs : 0;
     this.setState({debouncedTimeout});
   };
 
@@ -77,7 +79,7 @@ export default class DebouncedLayout extends React.Component {
           {this.props.cols[this.state.currentBreakpoint]} columns)
         </div>
         <button onClick={this.onNewLayout}>Generate New Layout</button>
-        <button onClick={this.onDebouncedTimoutChange}>
+        <button onClick={this.onDebouncedTimeoutChange}>
           {this.state.debouncedTimeout === 0 ? "No debouncing" : `Debouncing ${this.state.debouncedTimeout}ms`}
         </button>
         <ResponsiveReactGridLayout
@@ -115,6 +117,6 @@ function generateLayout(resizeHandles) {
   });
 }
 
-if (process.env.STATIC_EXAMPLES === true) {
+if (process.env.STATIC_EXAMPLES === "true") {
   import("../test-hook.jsx").then(fn => fn.default(DebouncedLayout));
 }

--- a/test/examples/22-debounced-layout-change.jsx
+++ b/test/examples/22-debounced-layout-change.jsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import _ from "lodash";
+import Responsive from '../../src/legacy/ResponsiveReactGridLayout';
+import WidthProvider from '../../src/legacy/WidthProvider';
+
+const ResponsiveReactGridLayout = WidthProvider(Responsive);
+
+export default class DebouncedLayout extends React.Component {
+  static defaultProps = {
+    className: "layout",
+    rowHeight: 30,
+    onLayoutChange: function() {},
+    cols: { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 },
+  };
+
+  state = {
+    currentBreakpoint: "lg",
+    debouncedTimeout: 500,
+    mounted: false,
+    layouts: { lg: generateLayout(['se']) }
+  };
+
+  componentDidMount() {
+    this.setState({ mounted: true });
+  }
+
+  generateDOM() {
+    return _.map(this.state.layouts.lg, function(l, i) {
+      return (
+        <div key={i} className={l.static ? "static" : ""}>
+          {l.static ? (
+            <span
+              className="text"
+              title="This item is static and cannot be removed or resized."
+            >
+              Static - {i}
+            </span>
+          ) : (
+            <span className="text">{i}</span>
+          )}
+        </div>
+      );
+    });
+  }
+
+  onBreakpointChange = (breakpoint) => {
+    this.setState({
+      currentBreakpoint: breakpoint
+    });
+  };
+
+  onDebouncedTimoutChange = () => {
+    const debouncedTimeout = this.state.debouncedTimeout === 0 ? 500 : 0;
+    this.setState({debouncedTimeout});
+  };
+
+  onLayoutChange = (layout, layouts) => {
+    console.log(`Layout changed after ${this.state.debouncedTimeout}ms`, layout, layouts);
+    this.props.onLayoutChange(layout, layouts);
+  };
+
+  onNewLayout = () => {
+    this.setState({
+      layouts: { lg: generateLayout(this.state.resizeHandles) }
+    });
+  };
+
+  onDrop = (elemParams) => {
+    alert(`Element parameters: ${JSON.stringify(elemParams)}`);
+  };
+
+  render() {
+    return (
+      <div>
+        <div>
+          Current Breakpoint: {this.state.currentBreakpoint} (
+          {this.props.cols[this.state.currentBreakpoint]} columns)
+        </div>
+        <button onClick={this.onNewLayout}>Generate New Layout</button>
+        <button onClick={this.onDebouncedTimoutChange}>
+          {this.state.debouncedTimeout === 0 ? "No debouncing" : `Debouncing ${this.state.debouncedTimeout}ms`}
+        </button>
+        <ResponsiveReactGridLayout
+          {...this.props}
+          layouts={this.state.layouts}
+          onBreakpointChange={this.onBreakpointChange}
+          onLayoutChange={this.onLayoutChange}
+          onDrop={this.onDrop}
+          // WidthProvider option
+          measureBeforeMount={false}
+          // I like to have it animate on mount. If you don't, delete `useCSSTransforms` (it's default `true`)
+          // and set `measureBeforeMount={true}`.
+          useCSSTransforms={this.state.mounted}
+          debounceTimeout={this.state.debouncedTimeout}
+        >
+          {this.generateDOM()}
+        </ResponsiveReactGridLayout>
+      </div>
+    );
+  }
+}
+
+function generateLayout(resizeHandles) {
+  return _.map(_.range(0, 25), function(item, i) {
+    var y = Math.ceil(Math.random() * 4) + 1;
+    return {
+      x: Math.round(Math.random() * 5) * 2,
+      y: Math.floor(i / 6) * y,
+      w: 2,
+      h: y,
+      i: i.toString(),
+      static: Math.random() < 0.05,
+      resizeHandles
+    };
+  });
+}
+
+if (process.env.STATIC_EXAMPLES === true) {
+  import("../test-hook.jsx").then(fn => fn.default(DebouncedLayout));
+}


### PR DESCRIPTION
## Description

The original `useContainerWidth` hook implementation uses `ResizeObserver` to provide reactive width updates which cause a performance issue during rapid resizing of the browser window because it triggers a large number of re-renders as the width changes continuously.

This can lead to a poor user experience, lot of repaints and sometimes a broken user-interface.

The enhancement focuses on providing more control and flexibility over container width measurement and updates, allowing for optional debouncing of resize events to optimize performance during rapid resizing.

This PR. adds an optional `debounceTimeout` property in `UseContainerWidthOptions` interface to trigger a resize of grid-item after a delay of specified milliseconds, if provided.

By default it is set to `zero` and the reactive resizing of the grid-items would be the default behavior if this is not set to a meaningful positive number.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!--
Please use this format to link issue numbers: "Fixes #123"
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #2254

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 📓 examples
- [ ] 🙅 no documentation needed

<!--
  PRs with deleted sections will be marked invalid.

  Please do not commit built files (`/dist`) to pull requests. They are built only at release.
  PRs with changes to `/dist` or version increments in package.json will be rejected.
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debouncing option for resize handling (debounceTimeout) so browser resizes can be delayed while drag/resize remain immediate.
* **Examples**
  * New interactive example showing debounce toggling, current breakpoint/column info, and buttons to toggle timeout and generate a new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->