### PR TITLE
fix: forward ref from legacy Responsive

### DIFF
--- a/src/legacy/ResponsiveReactGridLayout.tsx
+++ b/src/legacy/ResponsiveReactGridLayout.tsx
@@ -132,8 +132,17 @@ export interface LegacyResponsiveReactGridLayoutProps<
  *
  * Converts v1 flat props to v2 composable interfaces for backwards compatibility.
  */
-function ResponsiveReactGridLayout<B extends Breakpoint = string>(
-  props: LegacyResponsiveReactGridLayoutProps<B>
+function setRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+function ResponsiveReactGridLayoutInner<B extends Breakpoint = string>(
+  props: LegacyResponsiveReactGridLayoutProps<B>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>
 ) {
   const {
     // Required
@@ -198,6 +207,14 @@ function ResponsiveReactGridLayout<B extends Breakpoint = string>(
     onDrop,
     onDropDragOver
   } = props;
+
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setRef(innerRef, node);
+      setRef(forwardedRef, node);
+    },
+    [forwardedRef, innerRef]
+  );
 
   // Handle deprecated verticalCompact prop
   let compactType: CompactType =
@@ -264,7 +281,7 @@ function ResponsiveReactGridLayout<B extends Breakpoint = string>(
       autoSize={autoSize}
       className={className}
       style={style}
-      innerRef={innerRef}
+      innerRef={mergedRef}
       onBreakpointChange={onBreakpointChange}
       onLayoutChange={onLayoutChange}
       onWidthChange={onWidthChange}
@@ -283,7 +300,18 @@ function ResponsiveReactGridLayout<B extends Breakpoint = string>(
 }
 
 // Static properties for backwards compatibility
-ResponsiveReactGridLayout.displayName = "ResponsiveReactGridLayout";
+const ForwardedResponsiveReactGridLayout = React.forwardRef(
+  ResponsiveReactGridLayoutInner
+);
+ForwardedResponsiveReactGridLayout.displayName = "ResponsiveReactGridLayout";
+
+type ResponsiveReactGridLayoutComponent = <B extends Breakpoint = string>(
+  props: LegacyResponsiveReactGridLayoutProps<B> &
+    React.RefAttributes<HTMLDivElement>
+) => React.ReactElement | null;
+
+const ResponsiveReactGridLayout =
+  ForwardedResponsiveReactGridLayout as ResponsiveReactGridLayoutComponent;
 
 export default ResponsiveReactGridLayout;
 export { ResponsiveReactGridLayout, ResponsiveReactGridLayout as Responsive };

--- a/test/spec/backcompat-test.js
+++ b/test/spec/backcompat-test.js
@@ -484,6 +484,26 @@ describe("Backwards Compatibility: resizeHandles", () => {
 describe("Backwards Compatibility: Responsive Grid", () => {
   const ResponsiveRGL = WidthProvider(ResponsiveReactGridLayout);
 
+  it("forwards ref to the grid container while preserving innerRef", () => {
+    const ref = React.createRef();
+    const innerRef = React.createRef();
+
+    render(
+      <ResponsiveReactGridLayout
+        ref={ref}
+        innerRef={innerRef}
+        width={1200}
+        layouts={{ lg: [{ i: "a", x: 0, y: 0, w: 4, h: 2 }] }}
+      >
+        <div key="a">A</div>
+      </ResponsiveReactGridLayout>
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toBe(innerRef.current);
+    expect(ref.current).toHaveClass("react-grid-layout");
+  });
+
   it("uses correct layout for current breakpoint", () => {
     const onLayoutChange = jest.fn();
 


### PR DESCRIPTION
## Description

This PR fixes the legacy `Responsive` component so a standard React `ref` is forwarded to its grid container.

`ResponsiveReactGridLayout` was a plain function component, so React discarded `ref` and left `ref.current` as `null`. The wrapper now uses `React.forwardRef<HTMLDivElement>`, merges the forwarded ref with the existing `innerRef`, and passes the merged ref through the current container-ref path. Its generic breakpoint props remain intact, and generated CJS/ESM declarations now expose `RefAttributes<HTMLDivElement>`.

Validation:

- 16 Jest suites passed: 525 tests passed, 8 skipped, 2 snapshots passed.
- `npm run lint`
- `npm run typecheck`
- `npm run fmt:check`
- `npm run build`, including CJS/ESM and declaration generation.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2244.

## Mobile & Desktop Screenshots/Recordings

Not applicable; this change has no visual output.

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [x] 🙅 no documentation needed
