### PR TITLE
fix: round measured container width to whole pixels (#2271)

### DIFF
--- a/src/react/components/WidthProvider.tsx
+++ b/src/react/components/WidthProvider.tsx
@@ -80,7 +80,11 @@ export function WidthProvider<P extends { width: number }>(
 
       const observer = new ResizeObserver(entries => {
         if (entries[0]) {
-          const newWidth = entries[0].contentRect.width;
+          // Round to whole pixels. At fractional devicePixelRatio the measured
+          // width drifts sub-pixel between notifications; unrounded, every one
+          // is a new value that re-renders the grid and provokes the next
+          // notification (#2271).
+          const newWidth = Math.round(entries[0].contentRect.width);
 
           // Defer state update to next paint cycle to avoid
           // "ResizeObserver loop completed with undelivered notifications" error (#1959)
@@ -88,7 +92,7 @@ export function WidthProvider<P extends { width: number }>(
             cancelAnimationFrame(rafId);
           }
           rafId = requestAnimationFrame(() => {
-            setWidth(newWidth);
+            setWidth(prev => (prev === newWidth ? prev : newWidth));
             rafId = null;
           });
         }

--- a/src/react/hooks/useContainerWidth.ts
+++ b/src/react/hooks/useContainerWidth.ts
@@ -81,8 +81,10 @@ export function useContainerWidth(
   const measureWidth = useCallback(() => {
     const node = containerRef.current;
     if (node) {
-      const newWidth = node.offsetWidth;
-      setWidth(newWidth);
+      // offsetWidth is already whole-pixel; keep it consistent with the
+      // ResizeObserver path so the two sources cannot disagree (#2271).
+      const newWidth = Math.round(node.offsetWidth);
+      setWidth(prev => (prev === newWidth ? prev : newWidth));
       if (!mounted) {
         setMounted(true);
       }
@@ -103,8 +105,13 @@ export function useContainerWidth(
       observerRef.current = new ResizeObserver(entries => {
         const entry = entries[0];
         if (entry) {
-          // Use contentRect.width for consistent measurements
-          const newWidth = entry.contentRect.width;
+          // Round to whole pixels. At fractional devicePixelRatio (DevTools
+          // device-toolbar zoom at 75%/50%, OS display scaling) contentRect.width
+          // is fractional and drifts by sub-pixel amounts between notifications.
+          // Unrounded, every notification is a new value, so React never bails
+          // out: each one re-renders the grid, which changes the container
+          // height, which produces another notification (#2271).
+          const newWidth = Math.round(entry.contentRect.width);
 
           // Defer state update to next paint cycle to avoid
           // "ResizeObserver loop completed with undelivered notifications" error (#1959)
@@ -112,7 +119,7 @@ export function useContainerWidth(
             cancelAnimationFrame(rafId);
           }
           rafId = requestAnimationFrame(() => {
-            setWidth(newWidth);
+            setWidth(prev => (prev === newWidth ? prev : newWidth));
             rafId = null;
           });
         }

--- a/test/spec/responsive-settle-test.tsx
+++ b/test/spec/responsive-settle-test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for #2271 — the amplifier half.
+ *
+ * ResponsiveGridLayout's width effect, derived-layout effect and GridLayout's
+ * layout-sync effect all setState synchronously during the passive-effect
+ * flush. If any hop is not idempotent, a width change cascades instead of
+ * settling, which is what trips React's nested-update guard.
+ */
+import * as React from "react";
+import { useState, useCallback, useRef } from "react";
+import { render, act } from "@testing-library/react";
+import { ResponsiveGridLayout } from "../../src/react/components/ResponsiveGridLayout";
+import type { Layout, ResponsiveLayouts } from "../../src/core/types";
+
+const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
+const COLS = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
+
+function makeLayout(): Layout {
+  return Array.from({ length: 12 }, (_, i) => ({
+    i: `i-${i}`,
+    x: (i % 4) * 3,
+    y: Math.floor(i / 4) * 3,
+    w: 3,
+    h: 2 + (i % 3),
+    static: i === 5
+  }));
+}
+
+describe("#2271 responsive settling", () => {
+  let renders = 0;
+  let layoutChanges = 0;
+  let lastLayout: Layout = [];
+
+  function Harness({ width, echo }: { width: number; echo: boolean }) {
+    renders++;
+    const [layouts, setLayouts] = useState<ResponsiveLayouts<string>>(() => ({
+      lg: makeLayout()
+    }));
+    const onLayoutChange = useCallback(
+      (l: Layout, ls: ResponsiveLayouts<string>) => {
+        layoutChanges++;
+        lastLayout = l;
+        if (echo) setLayouts(ls);
+      },
+      [echo]
+    );
+    // New child elements every render, same keys - the showcase's pattern.
+    const nonce = useRef(0);
+    nonce.current++;
+    return (
+      <ResponsiveGridLayout
+        width={width}
+        breakpoints={BREAKPOINTS}
+        cols={COLS}
+        layouts={layouts}
+        rowHeight={30}
+        onLayoutChange={onLayoutChange}
+      >
+        {makeLayout().map(item => (
+          <div key={item.i}>
+            {item.i}-{nonce.current}
+          </div>
+        ))}
+      </ResponsiveGridLayout>
+    );
+  }
+
+  beforeEach(() => {
+    renders = 0;
+    layoutChanges = 0;
+    lastLayout = [];
+  });
+
+  it.each([
+    ["controlled (layouts echoed back)", true],
+    ["uncontrolled", false]
+  ])("settles when width sweeps breakpoints — %s", (_name, echo) => {
+    const useEcho = echo as boolean;
+    const { rerender } = render(<Harness width={1300} echo={useEcho} />);
+
+    // Sweep across every breakpoint boundary, repeatedly.
+    const sweep = [1300, 1100, 900, 700, 400, 700, 900, 1100, 1300];
+    for (let pass = 0; pass < 20; pass++) {
+      for (const w of sweep) {
+        act(() => {
+          rerender(<Harness width={w} echo={useEcho} />);
+        });
+      }
+    }
+
+    // A single width change must produce a bounded number of renders.
+    const before = renders;
+    act(() => {
+      rerender(<Harness width={900} echo={useEcho} />);
+    });
+    expect(renders - before).toBeLessThan(10);
+
+    // Re-applying the same width must not move any state.
+    const quiet = renders;
+    const quietChanges = layoutChanges;
+    act(() => {
+      rerender(<Harness width={900} echo={useEcho} />);
+    });
+    expect(renders - quiet).toBeLessThanOrEqual(1);
+    expect(layoutChanges - quietChanges).toBe(0);
+  });
+
+  it("returns to the original layout after a round trip", () => {
+    const { rerender } = render(<Harness width={1300} echo={true} />);
+
+    for (const w of [700, 400, 900, 1300]) {
+      act(() => {
+        rerender(<Harness width={w} echo={true} />);
+      });
+    }
+
+    // Back at lg, every item must be at its authored width again.
+    expect(lastLayout.map(l => l.w)).toEqual(makeLayout().map(l => l.w));
+  });
+});

--- a/test/spec/subpixel-width-test.tsx
+++ b/test/spec/subpixel-width-test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for #2271.
+ *
+ * Fractional container widths (device-toolbar zoom at 75%/50%, fractional
+ * devicePixelRatio) made every ResizeObserver notification a new `width` value.
+ * React never bailed out, so each notification re-rendered the grid, which
+ * changed the container height, which produced another notification.
+ *
+ * Width is a layout input measured in whole pixels. Sub-pixel deltas must not
+ * produce new state.
+ */
+import * as React from "react";
+import { render, act } from "@testing-library/react";
+import { useContainerWidth } from "../../src/react/hooks/useContainerWidth";
+import { WidthProvider } from "../../src/react/components/WidthProvider";
+
+declare const triggerResize: (width: number, height?: number) => void;
+
+describe("#2271 sub-pixel width stability", () => {
+  describe("useContainerWidth", () => {
+    const widths: number[] = [];
+
+    function Probe() {
+      const { width, containerRef } = useContainerWidth();
+      widths.push(width);
+      return <div ref={containerRef} />;
+    }
+
+    beforeEach(() => {
+      widths.length = 0;
+    });
+
+    it("reports whole-pixel widths", () => {
+      render(<Probe />);
+      act(() => {
+        triggerResize(1023 + 1 / 3);
+      });
+      expect(widths[widths.length - 1]).toBe(1023);
+    });
+
+    it("does not re-render for sub-pixel deltas", () => {
+      render(<Probe />);
+      act(() => {
+        triggerResize(1023.2);
+      });
+      const settled = widths.length;
+
+      // React may re-render a component once before bailing out on an equal
+      // state value, so allow one. What must not happen is a render per
+      // notification - that is the feedback loop.
+      for (const w of [1023.31, 1023.47, 1022.98, 1023.02, 1022.51]) {
+        act(() => {
+          triggerResize(w);
+        });
+      }
+
+      expect(widths.length).toBeLessThanOrEqual(settled + 1);
+      expect(new Set(widths.slice(settled - 1))).toEqual(new Set([1023]));
+    });
+
+    it("still tracks real width changes", () => {
+      render(<Probe />);
+      act(() => {
+        triggerResize(1023.2);
+      });
+      act(() => {
+        triggerResize(996.6);
+      });
+      expect(widths[widths.length - 1]).toBe(997);
+    });
+  });
+
+  describe("WidthProvider", () => {
+    const widths: number[] = [];
+
+    function Probe({
+      width,
+      innerRef
+    }: {
+      width: number;
+      innerRef?: React.Ref<HTMLDivElement>;
+    }) {
+      widths.push(width);
+      return <div ref={innerRef} />;
+    }
+    const Wrapped = WidthProvider(Probe);
+
+    beforeEach(() => {
+      widths.length = 0;
+    });
+
+    it("reports whole-pixel widths and ignores sub-pixel deltas", () => {
+      render(<Wrapped />);
+      act(() => {
+        triggerResize(1199 + 2 / 3);
+      });
+      expect(widths[widths.length - 1]).toBe(1200);
+
+      const settled = widths.length;
+      act(() => {
+        triggerResize(1199.71);
+      });
+      act(() => {
+        triggerResize(1200.24);
+      });
+      expect(widths.length).toBe(settled);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2271.

## What was wrong

`ResizeObserver` reports `contentRect.width` as a fractional value when `devicePixelRatio` isn't an integer. That happens with DevTools device-toolbar zoom at 75% or 50%, and with OS display scaling. Both measurement paths passed that value straight into `setWidth` with no equality guard, so React never bailed out. Every notification carried a genuinely new width, which re-rendered the grid, which changed the container height, which produced the next notification.

At 100% zoom the numbers come out whole, successive notifications are identical, React bails, and the chain dies. That's the zoom dependence in the report.

## Why it throws "Maximum update depth exceeded"

`setWidth` is deferred through `requestAnimationFrame`, so on its own it can't trip React's nested-update guard. Each frame is a fresh event-loop turn.

What the churn does is feed the synchronous passive-effect chain below it: `ResponsiveGridLayout`'s width effect, its derived-layout effect, `GridLayout`'s layout-sync effect, then back up through `onLayoutChange`. Four or five state updates across two components, same root, every frame for as long as the drag lasts.

The chain itself turned out to be fine. `responsive-settle-test.tsx` drives 180 breakpoint crossings in both controlled and uncontrolled modes and settles every time, with `ResponsiveGridLayout` untouched. Only the input needed fixing.

## The fix

Round the measured width to whole pixels, and guard the setter with `setWidth(prev => prev === next ? prev : next)`. Both in `useContainerWidth` and in `WidthProvider`.

`WidthProvider` matters as much as the hook here: the 00-showcase demo in the report goes through the legacy HOC, so fixing only `useContainerWidth` would have left the published demo broken.

1.5.3 measured `offsetWidth`, which is an integer. That's why 1.x never showed this.

## Tests

`subpixel-width-test.tsx` drives a mock `ResizeObserver` with fractional widths. Four cases, all failing on master, all passing here.

`responsive-settle-test.tsx` covers the chain downstream: one width change stays under 10 renders, and re-applying the same width emits no `onLayoutChange` at all.

Full suite passes (531 tests). Lint and `tsc` clean. Spot-checked in a browser at 75% zoom, where a 975.297px container now produces whole-pixel item widths.

## What I couldn't do

I never got "Maximum update depth exceeded" to fire in a test harness. The trigger is identified and fixed with a failing-then-passing test, and the chain downstream is shown to settle, but the link between the two is inference rather than a captured repro. Worth remembering if this comes back.

## Follow-up, not here

`measureWidth` reads `offsetWidth`, which includes padding and border. The observer reads `contentRect.width`, which doesn't. Both are integers now, so the disagreement costs at most one extra render at mount instead of a cycle, but it should still be reconciled.


https://claude.ai/code/session_01H9VtDFq3WWiozdaMW8Q4rM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout stability by rounding container widths to whole pixels.
  * Prevented unnecessary re-renders and repeated layout updates caused by sub-pixel resize changes.
  * Preserved correct updates when container widths cross whole-pixel boundaries.
  * Improved consistency when switching between responsive breakpoints.

* **Tests**
  * Added regression coverage for resize settling, breakpoint transitions, and sub-pixel width changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->