### PR TITLE
fix: pass the native event to resize callbacks (#2264)

### DIFF
--- a/src/react/components/GridItem.tsx
+++ b/src/react/components/GridItem.tsx
@@ -613,7 +613,7 @@ export function GridItem(props: GridItemProps): ReactElement {
 
   const onResizeHandler = useCallback(
     (
-      e: React.SyntheticEvent,
+      e: React.SyntheticEvent | Event,
       { node, size, handle: resizeHandle }: ResizeCallbackData,
       position: Position,
       handlerName: "onResizeStart" | "onResize" | "onResizeStop"
@@ -662,7 +662,11 @@ export function GridItem(props: GridItemProps): ReactElement {
       );
 
       handler(i, newW, newH, {
-        e: e.nativeEvent,
+        // react-resizable forwards react-draggable's callback event, which is
+        // already a native MouseEvent/TouchEvent and has no `nativeEvent`.
+        // Reading it unconditionally handed consumers `undefined` (#2264).
+        // The drag handlers above pass the raw event for the same reason.
+        e: (e as React.SyntheticEvent).nativeEvent ?? (e as Event),
         node,
         size: updatedSize,
         handle: resizeHandle

--- a/test/spec/resize-event-test.tsx
+++ b/test/spec/resize-event-test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Regression test for #2264.
+ *
+ * react-resizable forwards react-draggable's callback event, which is already a
+ * native MouseEvent/TouchEvent and has no `nativeEvent` property. GridItem read
+ * `e.nativeEvent` unconditionally, so every onResizeStart/onResize/onResizeStop
+ * consumer received `undefined` as the event.
+ *
+ * GridItem's four drag handlers already pass the raw event. Resize must match.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import type { ResizeCallbackData } from "react-resizable";
+
+// Capture the resize callbacks react-resizable would be driving, so the test can
+// invoke them with the event shape react-draggable actually delivers.
+type ResizeHandler = (e: unknown, data: ResizeCallbackData) => void;
+const captured: {
+  onResizeStart?: ResizeHandler;
+  onResize?: ResizeHandler;
+  onResizeStop?: ResizeHandler;
+}[] = [];
+
+jest.mock("react-resizable", () => {
+  const actual = jest.requireActual("react-resizable");
+  return {
+    ...actual,
+    Resizable: (props: Record<string, unknown>) => {
+      captured.push({
+        onResizeStart: props.onResizeStart as ResizeHandler | undefined,
+        onResize: props.onResize as ResizeHandler | undefined,
+        onResizeStop: props.onResizeStop as ResizeHandler | undefined
+      });
+      const { Resizable: ActualResizable } = actual;
+      return <ActualResizable {...props} />;
+    }
+  };
+});
+
+// Import GridItem AFTER the mock is set up
+import { GridItem, type GridItemProps } from "../../src/react/index";
+
+describe("#2264 resize callback event", () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  function renderItem(overrides: Partial<GridItemProps> = {}) {
+    const props: GridItemProps = {
+      children: <div>child</div>,
+      cols: 12,
+      containerWidth: 1200,
+      rowHeight: 30,
+      margin: [10, 10] as const,
+      maxRows: 10,
+      containerPadding: [10, 10] as const,
+      i: "0",
+      x: 0,
+      y: 0,
+      w: 3,
+      h: 2,
+      isDraggable: false,
+      isResizable: true,
+      isBounded: false,
+      useCSSTransforms: false,
+      ...overrides
+    };
+    render(<GridItem {...props} />);
+    const last = captured[captured.length - 1];
+    if (!last) throw new Error("Resizable was never rendered");
+    return last;
+  }
+
+  function resizeData(node: HTMLElement): ResizeCallbackData {
+    return {
+      node,
+      size: { width: 300, height: 80 },
+      handle: "se"
+    } as ResizeCallbackData;
+  }
+
+  it.each(["onResizeStart", "onResize", "onResizeStop"] as const)(
+    "%s receives the native event, not undefined",
+    handlerName => {
+      const received: unknown[] = [];
+      const handlers = renderItem({
+        [handlerName]: (
+          _i: string,
+          _w: number,
+          _h: number,
+          data: { e: unknown }
+        ) => {
+          received.push(data.e);
+        }
+      });
+
+      const node = document.createElement("div");
+      // What react-draggable actually delivers: a raw DOM event with no
+      // `nativeEvent` property.
+      const nativeEvent = new MouseEvent("mousemove", { bubbles: true });
+      expect("nativeEvent" in nativeEvent).toBe(false);
+
+      handlers[handlerName]?.(nativeEvent, resizeData(node));
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toBe(nativeEvent);
+    }
+  );
+
+  it("still unwraps a React SyntheticEvent when given one", () => {
+    const received: unknown[] = [];
+    const handlers = renderItem({
+      onResize: (_i: string, _w: number, _h: number, data: { e: unknown }) => {
+        received.push(data.e);
+      }
+    });
+
+    const node = document.createElement("div");
+    const inner = new MouseEvent("mousemove", { bubbles: true });
+    const synthetic = { nativeEvent: inner, type: "mousemove" };
+
+    handlers.onResize?.(synthetic, resizeData(node));
+
+    expect(received[0]).toBe(inner);
+  });
+});


### PR DESCRIPTION
Fixes #2264.

## The bug

`react-resizable` forwards `react-draggable`'s callback event, which is already a native `MouseEvent` or `TouchEvent`. It has no `nativeEvent` property. `GridItem` read `e.nativeEvent` unconditionally, so every `onResizeStart`, `onResize` and `onResizeStop` consumer got `undefined` where the event should be.

The parameter was typed `React.SyntheticEvent`, which is what hid it. TypeScript was happy; the runtime value never matched the type.

## Why the drag callbacks were fine

`GridItem` has five event paths. The four drag ones already pass the raw event through:

```ts
e: e as unknown as Event,
```

Resize was the only one unwrapping, and it was unwrapping something that was never wrapped.

## The fix

Fall back to the raw event, and keep unwrapping a genuine `SyntheticEvent` if one ever arrives, so both shapes work:

```ts
e: (e as React.SyntheticEvent).nativeEvent ?? (e as Event),
```

The parameter type widens to `React.SyntheticEvent | Event` so it describes what actually shows up.

Diagnosis and patch are the reporter's. I confirmed both against current `master` and added coverage.

## Tests

`test/spec/resize-event-test.tsx` mocks `react-resizable` to capture the callbacks `GridItem` hands it, then invokes them with a real `MouseEvent`, the shape `react-draggable` delivers. Four cases: one per resize callback, plus one asserting a genuine `SyntheticEvent` still gets unwrapped.

The three native-event cases fail on `master` and pass here. The `SyntheticEvent` case passes both ways, which is the point: it pins the existing behaviour so the fallback can't quietly change it.

Full suite passes (535 tests). Lint, `tsc` and build clean.

## Note on ownership

@pupuking723 offered to take this in April and nothing landed, so I picked it up. Happy to close this in favour of theirs if they'd rather finish it.

https://claude.ai/code/session_01H9VtDFq3WWiozdaMW8Q4rM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resize callbacks so they consistently receive the underlying event when resizing with either native or React-generated events.
  * Prevented resize event data from being missing in certain interactions.

* **Tests**
  * Added coverage for native and React-style resize events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->