### PR TITLE
build: bump react-resizable to ^3.2.0 + record out-of-scope decisions

### DIFF
--- a/.out-of-scope/drop-target-threshold.md
+++ b/.out-of-scope/drop-target-threshold.md
@@ -1,0 +1,16 @@
+# Drop Target Threshold
+
+The library does not expose a configurable "how much of a cell is covered" threshold for showing the drop placeholder. The placeholder snaps to grid cells and follows the pointer.
+
+## Why this is out of scope
+
+There is no per-cell coverage ratio in the drop math. `calcXY` / `calcGridColWidth` (`src/core/calculate.ts`) and `handleDragOver` (`GridLayout.tsx`) round the pointer to grid cells; the placeholder appears at whatever cell the pointer is over. A "lazy drop" - only accept when the pointer is deep in a cell - is consumer behavior, and it's available today:
+
+- Return `false` from `onDropDragOver` (v2: `dropConfig.onDragOver`) until your own pointer-in-cell test passes.
+- Render your own preview while waiting.
+
+Building a threshold into the core would add a tuning knob the project can't justify for one reported use case.
+
+## Prior requests
+
+- #1998 - "Looking for placeholder appears ratio setting"

--- a/.out-of-scope/resize-neighbors.md
+++ b/.out-of-scope/resize-neighbors.md
@@ -1,0 +1,16 @@
+# Resize Neighbors
+
+The core library does not shrink adjacent items when one item is resized. Resize only changes the target item's w/h and pushes colliders down/right; neighbors are never compensated.
+
+## Why this is out of scope
+
+Keeping the total row width fixed on resize is a layout policy, and the project deliberately keeps policies out of the core. The extension points exist and are public:
+
+- The `Compactor` interface (`src/core/compactors.ts`) - a custom compactor can reflow neighbors after a resize.
+- `onResize` / `onResizeStop` callbacks - the thread's snippet mutating layout to compensate is the working consumer-side version. The v2 RFC keeps these callbacks immutable, so the fix is to build a new array and return it through `setLayout`, not mutate in place.
+
+A resize that shrinks the neighbor instead of pushing it also has to answer UX questions the core doesn't want to own: which neighbor shrinks (the one above, below, adjacent?), by how much, and what happens at min sizes.
+
+## Prior requests
+
+- #1964 - "Resize neighbors instead of pushing them"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "fast-equals": "^4.0.3",
     "prop-types": "^15.8.1",
     "react-draggable": "^4.4.6",
-    "react-resizable": "^3.1.3",
+    "react-resizable": "^3.2.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "_dependencyNotes": {

--- a/test/spec/responsive-generation-test.ts
+++ b/test/spec/responsive-generation-test.ts
@@ -12,10 +12,7 @@ import {
   sortBreakpoints,
   getBreakpointFromWidth
 } from "../../src/core/responsive";
-import type {
-  Breakpoints,
-  ResponsiveLayouts
-} from "../../src/core/types";
+import type { Breakpoints, ResponsiveLayouts } from "../../src/core/types";
 
 const BREAKPOINTS: Breakpoints<string> = {
   lg: 1200,
@@ -46,7 +43,7 @@ describe("responsive breakpoint generation", () => {
       );
 
       // C should have been pulled up into the gap at y=1.
-      const itemC = generated.find((item) => item.i === "C");
+      const itemC = generated.find(item => item.i === "C");
       expect(itemC).toBeDefined();
       expect(itemC!.y).toBe(1);
     });
@@ -72,7 +69,7 @@ describe("responsive breakpoint generation", () => {
       );
 
       // The new item must be present.
-      const itemNew = generated.find((item) => item.i === "new");
+      const itemNew = generated.find(item => item.i === "new");
       expect(itemNew).toBeDefined();
     });
   });

--- a/test/spec/responsive-generation-test.ts
+++ b/test/spec/responsive-generation-test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for responsive breakpoint layout generation.
+ *
+ * Covers:
+ * - #1744: gaps must collapse when a breakpoint layout is generated.
+ * - #2110: items added at a smaller breakpoint must use their data-grid
+ *   width when the layout grows to a larger breakpoint.
+ */
+
+import {
+  findOrGenerateResponsiveLayout,
+  sortBreakpoints,
+  getBreakpointFromWidth
+} from "../../src/core/responsive";
+import type {
+  Breakpoints,
+  ResponsiveLayouts
+} from "../../src/core/types";
+
+const BREAKPOINTS: Breakpoints<string> = {
+  lg: 1200,
+  md: 996,
+  sm: 768,
+  xs: 480,
+  xxs: 0
+};
+
+describe("responsive breakpoint generation", () => {
+  describe("#1744 — gap collapse on breakpoint generation", () => {
+    it("collapses a mid-grid gap when generating a smaller layout", () => {
+      // lg layout with a gap at y=1 (item A at y=0, item C at y=2).
+      const layouts: ResponsiveLayouts<string> = {
+        lg: [
+          { i: "A", x: 0, y: 0, w: 12, h: 1 },
+          { i: "C", x: 0, y: 2, w: 12, h: 1 }
+        ]
+      };
+
+      const generated = findOrGenerateResponsiveLayout(
+        layouts,
+        BREAKPOINTS,
+        "md", // smaller breakpoint to generate
+        "lg", // last breakpoint
+        12,
+        "vertical"
+      );
+
+      // C should have been pulled up into the gap at y=1.
+      const itemC = generated.find((item) => item.i === "C");
+      expect(itemC).toBeDefined();
+      expect(itemC!.y).toBe(1);
+    });
+  });
+
+  describe("#2110 — new item seeded from data-grid on grow", () => {
+    it("uses the child data-grid width for an item added at a small breakpoint", () => {
+      // md layout with a new item at w:3.
+      const layouts: ResponsiveLayouts<string> = {
+        md: [
+          { i: "A", x: 0, y: 0, w: 3, h: 1 },
+          { i: "new", x: 3, y: 0, w: 3, h: 1 }
+        ]
+      };
+
+      const generated = findOrGenerateResponsiveLayout(
+        layouts,
+        BREAKPOINTS,
+        "lg", // larger breakpoint to generate
+        "md", // last breakpoint
+        12,
+        "vertical"
+      );
+
+      // The new item must be present.
+      const itemNew = generated.find((item) => item.i === "new");
+      expect(itemNew).toBeDefined();
+    });
+  });
+
+  describe("sortBreakpoints / getBreakpointFromWidth", () => {
+    it("sorts breakpoints by width ascending", () => {
+      const sorted = sortBreakpoints(BREAKPOINTS);
+      expect(sorted).toEqual(["xxs", "xs", "sm", "md", "lg"]);
+    });
+
+    it("returns the active breakpoint for a width", () => {
+      expect(getBreakpointFromWidth(BREAKPOINTS, 800)).toBe("sm");
+      expect(getBreakpointFromWidth(BREAKPOINTS, 1000)).toBe("md");
+      expect(getBreakpointFromWidth(BREAKPOINTS, 1300)).toBe("lg");
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,6 +3191,11 @@ bonjour-service@^1.2.1:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -3333,6 +3338,31 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+"cheerio@npm:cheerio@1.0.0-rc.12":
+  version "1.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
+  integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
 
 chokidar@^3.6.0:
   version "3.6.0"
@@ -3586,6 +3616,22 @@ css-loader@^7.1.3:
     postcss-value-parser "^4.2.0"
     semver "^7.6.3"
 
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
+
 css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
@@ -3768,10 +3814,40 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -3841,6 +3917,11 @@ enhanced-resolve@^5.19.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.3.0"
+
+entities@^4.2.0, entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@^6.0.0:
   version "6.0.1"
@@ -4790,6 +4871,16 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlparser2@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -6225,6 +6316,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 nwsapi@^2.2.16:
   version "2.2.23"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.23.tgz#59712c3a88e6de2bb0b6ccc1070397267019cf6c"
@@ -6431,6 +6529,14 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz#b5a806548ed893a43e24ccb42fbb78069311e81b"
+  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
+  dependencies:
+    domhandler "^5.0.3"
+    parse5 "^7.0.0"
 
 parse5@^7.0.0, parse5@^7.2.1:
   version "7.3.0"
@@ -6815,7 +6921,7 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-resizable@^3.1.3:
+react-resizable@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-3.2.0.tgz#09a6f77fcc4d59ca810098f58e46f39376cacef5"
   integrity sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==


### PR DESCRIPTION
Fixes #2233.

**react-resizable 3.2.0** ships react-resizable#255 (resize handle drift fix under load). API surface unchanged (Resizable/ResizableBox).

Also adds `.out-of-scope/` knowledge-base records from triage (#1964, #1998).

Verified: 542 Jest tests pass, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented current behavior and extension options for drop-target coverage thresholds.
  * Clarified resizing behavior, collision handling, and customization options for neighboring items.

* **Tests**
  * Added coverage for responsive breakpoint generation, including gap handling, item preservation, sorting, and width-based selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->