### PR TITLE
fix: add constrainSize to containerBounds so isBounded bounds resize (#1779)

### DIFF
--- a/src/core/constraints.ts
+++ b/src/core/constraints.ts
@@ -128,6 +128,38 @@ export const containerBounds: LayoutConstraint = {
       x: clamp(x, 0, Math.max(0, cols - item.w)),
       y: clamp(y, 0, Math.max(0, visibleRows - item.h))
     };
+  },
+
+  constrainSize(
+    item: LayoutItem,
+    w: number,
+    h: number,
+    handle: ResizeHandleAxis,
+    { cols, maxRows, containerHeight, rowHeight, margin }: ConstraintContext
+  ): { w: number; h: number } {
+    // Same visible-rows calculation as constrainPosition, so a resize cannot
+    // push the item past the visible container even when maxRows is Infinity.
+    const visibleRows =
+      containerHeight > 0
+        ? Math.floor((containerHeight + margin[1]) / (rowHeight + margin[1]))
+        : maxRows;
+
+    // For west-side resizes the item expands leftward; the right edge is fixed.
+    const maxW =
+      handle === "w" || handle === "nw" || handle === "sw"
+        ? item.x + item.w
+        : cols - item.x;
+
+    // For north-side resizes the item expands upward; the bottom edge is fixed.
+    const maxH =
+      handle === "n" || handle === "nw" || handle === "ne"
+        ? item.y + item.h
+        : visibleRows - item.y;
+
+    return {
+      w: clamp(w, 1, Math.max(1, maxW)),
+      h: clamp(h, 1, Math.max(1, maxH))
+    };
   }
 };
 

--- a/test/spec/constraints-test.ts
+++ b/test/spec/constraints-test.ts
@@ -241,8 +241,53 @@ describe("Constraints", () => {
       expect(result.y).toBe(8); // maxRows - h = 10 - 2 = 8
     });
 
-    it("does not have constrainSize", () => {
-      expect(containerBounds.constrainSize).toBeUndefined();
+    it("constrains height to the visible container (#1779)", () => {
+      const item = createItem({ x: 0, y: 8, w: 2, h: 2 });
+      // visibleRows = floor((390 + 10) / (30 + 10)) = 10
+      const context = createContext({
+        cols: 12,
+        containerHeight: 390,
+        rowHeight: 30,
+        margin: [10, 10]
+      });
+
+      // A bottom (s) resize that would overflow the container is clamped.
+      const result = containerBounds.constrainSize!(item, 2, 5, "s", context);
+      expect(result.h).toBe(2); // visibleRows - y = 10 - 8 = 2
+    });
+
+    it("constrains width to the visible columns for e/se handles (#1779)", () => {
+      const item = createItem({ x: 10, y: 0, w: 2, h: 2 });
+      const context = createContext({ cols: 12, containerHeight: 390 });
+
+      const result = containerBounds.constrainSize!(item, 5, 2, "se", context);
+      expect(result.w).toBe(2); // cols - x = 12 - 10 = 2
+    });
+
+    it("falls back to maxRows when containerHeight is 0 (#1779)", () => {
+      const item = createItem({ x: 0, y: 8, w: 2, h: 2 });
+      const context = createContext({
+        cols: 12,
+        maxRows: 10,
+        containerHeight: 0
+      });
+
+      const result = containerBounds.constrainSize!(item, 2, 5, "s", context);
+      expect(result.h).toBe(2); // maxRows - y = 10 - 8 = 2
+    });
+
+    it("does not clamp when the item fits within the container (#1779)", () => {
+      const item = createItem({ x: 0, y: 0, w: 2, h: 2 });
+      const context = createContext({
+        cols: 12,
+        containerHeight: 390,
+        rowHeight: 30,
+        margin: [10, 10]
+      });
+
+      const result = containerBounds.constrainSize!(item, 3, 4, "se", context);
+      expect(result.w).toBe(3);
+      expect(result.h).toBe(4);
     });
   });
 


### PR DESCRIPTION
containerBounds had only constrainPosition; resize in a bounded grid could push items past the visible container. Mirrors the visible-rows calculation to clamp h/w.

Verified: 541 Jest tests pass, typecheck clean, 4 new constraint tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resizing is now constrained to the container’s visible bounds.
  * Width and height limits account for grid dimensions, resize direction, and available rows and columns.
  * Resized elements are prevented from becoming smaller than one unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->