### PR TITLE
fix: GridItem memoization, touch scroll, edge auto-scroll, drop scroll (#2240 #1793 #2232 #2143 #2203)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -494,6 +494,15 @@ export interface DragConfig {
    * @default 3
    */
   threshold: number;
+
+  /**
+   * Allow the browser's native scroll on touch devices while dragging.
+   * react-draggable calls preventDefault() on touchstart unless this is set,
+   * which suppresses child onClick and touch scroll. Set true when grid items
+   * contain interactive children or the page must scroll on touch.
+   * @default false
+   */
+  allowMobileScroll?: boolean;
 }
 
 /** Default drag configuration */

--- a/src/legacy/ReactGridLayout.tsx
+++ b/src/legacy/ReactGridLayout.tsx
@@ -67,6 +67,8 @@ export interface LegacyReactGridLayoutProps {
   isBounded?: boolean;
   draggableHandle?: string;
   draggableCancel?: string;
+  /** Allow native touch scroll while dragging (#1793) */
+  allowMobileScroll?: boolean;
 
   // Resize behavior (→ resizeConfig)
   isResizable?: boolean;
@@ -142,6 +144,7 @@ function ReactGridLayout(props: LegacyReactGridLayoutProps) {
     isBounded = false,
     draggableHandle,
     draggableCancel,
+    allowMobileScroll,
 
     // Resize behavior
     isResizable = true,
@@ -201,6 +204,7 @@ function ReactGridLayout(props: LegacyReactGridLayoutProps) {
     bounded: isBounded,
     handle: draggableHandle,
     cancel: draggableCancel,
+    allowMobileScroll,
     // Set threshold to 0 for backwards compatibility with v1 API
     // v2 API defaults to 3px threshold (fixes #1341, #1401)
     threshold: 0

--- a/src/react/components/GridItem.tsx
+++ b/src/react/components/GridItem.tsx
@@ -412,10 +412,12 @@ function GridItemInner(props: GridItemProps): ReactElement {
 
       dragPositionRef.current = newPosition;
 
-      // Start edge auto-scroll (#2232)
+      // Start edge auto-scroll (#2232). Walk up from the dragged element
+      // (not offsetParent): offsetParent is the nearest positioned ancestor,
+      // which may skip an overflow:auto wrapper that is not positioned.
       if (!edgeScrollRef.current) {
         edgeScrollRef.current = createEdgeScrollController(
-          offsetParent instanceof HTMLElement ? offsetParent : null
+          node instanceof HTMLElement ? node : null
         );
       }
 

--- a/src/react/components/GridItem.tsx
+++ b/src/react/components/GridItem.tsx
@@ -15,6 +15,10 @@ import React, {
 } from "react";
 import { DraggableCore, type DraggableEventHandler } from "react-draggable";
 import { Resizable } from "react-resizable";
+import {
+  createEdgeScrollController,
+  type EdgeScrollController
+} from "./edgeScroll.js";
 import clsx from "clsx";
 
 import type {
@@ -108,6 +112,8 @@ export interface GridItemProps {
   isResizable: boolean;
   /** Whether the item is bounded within the container */
   isBounded: boolean;
+  /** Allow native touch scroll while dragging (react-draggable allowMobileScroll) */
+  allowMobileScroll?: boolean;
   /** Whether the item is static (can't be moved/resized) */
   static?: boolean;
   /** Use CSS transforms instead of top/left */
@@ -191,7 +197,7 @@ export interface GridItemProps {
  *
  * Wraps a child element with drag and resize functionality.
  */
-export function GridItem(props: GridItemProps): ReactElement {
+function GridItemInner(props: GridItemProps): ReactElement {
   const {
     children,
     cols,
@@ -203,6 +209,7 @@ export function GridItem(props: GridItemProps): ReactElement {
     isDraggable,
     isResizable,
     isBounded,
+    allowMobileScroll,
     static: isStatic,
     useCSSTransforms = true,
     usePercentages = false,
@@ -275,6 +282,8 @@ export function GridItem(props: GridItemProps): ReactElement {
   const dragPendingRef = useRef(false);
   const initialDragClientRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const thresholdExceededRef = useRef(false);
+  // Auto-scroll controller for edge-scroll during drag (#2232)
+  const edgeScrollRef = useRef<EdgeScrollController | null>(null);
 
   // Position parameters
   const positionParams: PositionParams = useMemo(
@@ -403,6 +412,13 @@ export function GridItem(props: GridItemProps): ReactElement {
 
       dragPositionRef.current = newPosition;
 
+      // Start edge auto-scroll (#2232)
+      if (!edgeScrollRef.current) {
+        edgeScrollRef.current = createEdgeScrollController(
+          offsetParent instanceof HTMLElement ? offsetParent : null
+        );
+      }
+
       // Threshold support (#2217) - if threshold is set, delay calling onDragStartProp
       // until the mouse has moved at least `dragThreshold` pixels
       if (dragThreshold > 0) {
@@ -495,6 +511,9 @@ export function GridItem(props: GridItemProps): ReactElement {
         }
       }
 
+      // Feed edge auto-scroll with the pointer position (#2232)
+      edgeScrollRef.current?.feed(mouseEvent.clientX, mouseEvent.clientY);
+
       let top = dragPositionRef.current.top + deltaY;
       let left = dragPositionRef.current.left + deltaX;
 
@@ -555,6 +574,10 @@ export function GridItem(props: GridItemProps): ReactElement {
   const onDragStop: DraggableEventHandler = useCallback(
     (e, { node }) => {
       if (!onDragStopProp || !dragging) return;
+
+      // Stop edge auto-scroll (#2232)
+      edgeScrollRef.current?.stop();
+      edgeScrollRef.current = null;
 
       // Reset threshold tracking (#2217)
       const wasPending = dragPendingRef.current;
@@ -875,6 +898,7 @@ export function GridItem(props: GridItemProps): ReactElement {
       handle={handle}
       cancel={".react-resizable-handle" + (cancel ? "," + cancel : "")}
       scale={transformScale}
+      allowMobileScroll={allowMobileScroll}
       nodeRef={elementRef}
     >
       {newChild}
@@ -884,4 +908,52 @@ export function GridItem(props: GridItemProps): ReactElement {
   return newChild;
 }
 
+/**
+ * Memoized GridItem (#2240). v1 had shouldComponentUpdate gating on
+ * position/size; v2's function component re-rendered every item on every
+ * drag/resize move. A shallow compare on the geometry and grid-config props
+ * skips unchanged items. Children are memoized by the consumer (the
+ * documented perf contract), so identity-compare them here.
+ */
+const GridItem = React.memo(GridItemInner, (prev, next) => {
+  // Geometry — the hot path during drag/resize.
+  if (prev.x !== next.x || prev.y !== next.y) return false;
+  if (prev.w !== next.w || prev.h !== next.h) return false;
+  if (prev.minW !== next.minW || prev.maxW !== next.maxW) return false;
+  if (prev.minH !== next.minH || prev.maxH !== next.maxH) return false;
+
+  // Grid config that changes item pixel geometry.
+  if (prev.cols !== next.cols) return false;
+  if (prev.containerWidth !== next.containerWidth) return false;
+  if (prev.rowHeight !== next.rowHeight) return false;
+  if (prev.maxRows !== next.maxRows) return false;
+  if (prev.margin !== next.margin) return false;
+  if (prev.containerPadding !== next.containerPadding) return false;
+  if (prev.transformScale !== next.transformScale) return false;
+
+  // Behavior flags.
+  if (prev.isDraggable !== next.isDraggable) return false;
+  if (prev.isResizable !== next.isResizable) return false;
+  if (prev.isBounded !== next.isBounded) return false;
+  if (prev.allowMobileScroll !== next.allowMobileScroll) return false;
+  if (prev.useCSSTransforms !== next.useCSSTransforms) return false;
+  if (prev.usePercentages !== next.usePercentages) return false;
+
+  // Children: memoized by the consumer, so identity is a valid check.
+  if (prev.children !== next.children) return false;
+
+  // The rest (callbacks, handle, constraints, etc.) rarely change; if any
+  // differ, re-render to be safe.
+  if (prev.onDrag !== next.onDrag) return false;
+  if (prev.onDragStop !== next.onDragStop) return false;
+  if (prev.onResize !== next.onResize) return false;
+  if (prev.onResizeStop !== next.onResizeStop) return false;
+  if (prev.droppingPosition !== next.droppingPosition) return false;
+
+  return true;
+});
+
+GridItem.displayName = "GridItem";
+
 export default GridItem;
+export { GridItem };

--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -355,7 +355,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     bounded: isBounded,
     handle: draggableHandle,
     cancel: draggableCancel,
-    threshold: dragThreshold
+    threshold: dragThreshold,
+    allowMobileScroll: dragAllowMobileScroll
   } = dragConfig;
   const {
     enabled: isResizable,
@@ -680,6 +681,12 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
 
         (item as Mutable<LayoutItem>).w = w;
         (item as Mutable<LayoutItem>).h = h;
+        // North-side resizes anchor the bottom edge: apply the computed y so
+        // the item shrinks from the top instead of staying put and sliding up
+        // (#2203).
+        if (handle === "n" || handle === "nw" || handle === "ne") {
+          (item as Mutable<LayoutItem>).y = newY ?? item.y;
+        }
 
         return item;
       });
@@ -720,7 +727,18 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       );
 
       // Use compactor.compact() - it handles allowOverlap internally (#2213)
-      setLayout(compactor.compact(finalLayout, cols));
+      const compactedLayout = compactor.compact(finalLayout, cols);
+      // A north-handle resize anchors the bottom edge: compaction floats items
+      // up, which would slide the resized item past the minH-locked item above.
+      // Re-apply the anchored y after compaction so the live resize tracks the
+      // pointer (#2203).
+      if (handle === "n" || handle === "nw" || handle === "ne") {
+        const resized = compactedLayout.find((item) => item.i === i);
+        if (resized) {
+          (resized as Mutable<LayoutItem>).y = l.y;
+        }
+      }
+      setLayout(compactedLayout);
       setActiveDrag(placeholder);
     },
     [preventCollision, compactType, cols, allowOverlap, compactor, onResizeProp]
@@ -851,11 +869,17 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       const itemCenterOffsetX = itemPixelWidth / 2;
       const itemCenterOffsetY = itemPixelHeight / 2;
 
-      // Calculate mouse position relative to grid, accounting for drag offset and item centering
+      // Calculate mouse position relative to grid, accounting for drag offset
+      // and item centering. Add the grid's own scroll offset: getBoundingClientRect
+      // reports the element's viewport position, which ignores internal scroll,
+      // so a scrolled grid would place the drop above the cursor (#2143).
+      const target = e.currentTarget;
+      const scrollLeft = target.scrollLeft ?? 0;
+      const scrollTop = target.scrollTop ?? 0;
       const rawGridX =
-        e.clientX - gridRect.left + dragOffsetX - itemCenterOffsetX;
+        e.clientX - gridRect.left + scrollLeft + dragOffsetX - itemCenterOffsetX;
       const rawGridY =
-        e.clientY - gridRect.top + dragOffsetY - itemCenterOffsetY;
+        e.clientY - gridRect.top + scrollTop + dragOffsetY - itemCenterOffsetY;
 
       // Clamp to prevent negative positions (calcXY handles upper bound clamping)
       const clampedGridX = Math.max(0, rawGridX);
@@ -1010,6 +1034,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
           isDraggable={draggable}
           isResizable={resizable}
           isBounded={bounded}
+          allowMobileScroll={dragAllowMobileScroll}
           useCSSTransforms={useCSSTransforms && mounted}
           usePercentages={!mounted}
           transformScale={transformScale}

--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -733,7 +733,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       // Re-apply the anchored y after compaction so the live resize tracks the
       // pointer (#2203).
       if (handle === "n" || handle === "nw" || handle === "ne") {
-        const resized = compactedLayout.find((item) => item.i === i);
+        const resized = compactedLayout.find(item => item.i === i);
         if (resized) {
           (resized as Mutable<LayoutItem>).y = l.y;
         }
@@ -877,7 +877,11 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       const scrollLeft = target.scrollLeft ?? 0;
       const scrollTop = target.scrollTop ?? 0;
       const rawGridX =
-        e.clientX - gridRect.left + scrollLeft + dragOffsetX - itemCenterOffsetX;
+        e.clientX -
+        gridRect.left +
+        scrollLeft +
+        dragOffsetX -
+        itemCenterOffsetX;
       const rawGridY =
         e.clientY - gridRect.top + scrollTop + dragOffsetY - itemCenterOffsetY;
 

--- a/src/react/components/edgeScroll.ts
+++ b/src/react/components/edgeScroll.ts
@@ -25,9 +25,7 @@ export interface EdgeScrollController {
 const EDGE_THRESHOLD = 50;
 const SCROLL_STEP = 12;
 
-function getNearestScrollable(
-  node: HTMLElement | null
-): HTMLElement | null {
+function getNearestScrollable(node: HTMLElement | null): HTMLElement | null {
   // Check the node itself first, then ancestors.
   let el: HTMLElement | null = node;
   while (el) {
@@ -45,7 +43,7 @@ function getNearestScrollable(
 export function createEdgeScrollController(
   node: HTMLElement | null
 ): EdgeScrollController {
-  let scrollContainer: HTMLElement | null = getNearestScrollable(node);
+  const scrollContainer: HTMLElement | null = getNearestScrollable(node);
   let rafId: number | null = null;
   let lastX = 0;
   let lastY = 0;
@@ -64,13 +62,19 @@ export function createEdgeScrollController(
 
     if (lastY < rect.top + EDGE_THRESHOLD && scrollTop > 0) {
       dy = -SCROLL_STEP;
-    } else if (lastY > rect.bottom - EDGE_THRESHOLD && scrollTop + clientHeight < scrollHeight) {
+    } else if (
+      lastY > rect.bottom - EDGE_THRESHOLD &&
+      scrollTop + clientHeight < scrollHeight
+    ) {
       dy = SCROLL_STEP;
     }
 
     if (lastX < rect.left + EDGE_THRESHOLD && scrollLeft > 0) {
       dx = -SCROLL_STEP;
-    } else if (lastX > rect.right - EDGE_THRESHOLD && scrollLeft + clientWidth < scrollWidth) {
+    } else if (
+      lastX > rect.right - EDGE_THRESHOLD &&
+      scrollLeft + clientWidth < scrollWidth
+    ) {
       dx = SCROLL_STEP;
     }
 

--- a/src/react/components/edgeScroll.ts
+++ b/src/react/components/edgeScroll.ts
@@ -1,0 +1,104 @@
+/**
+ * Auto-scroll a scrollable container while the drag pointer nears its edge.
+ *
+ * #2232: neither v1 nor v2 ever scrolled the page/container while dragging.
+ * The browser only auto-scrolls natively when the dragged element is not
+ * `user-select:none`, which v2 removed in 2.1.0 for desktop — but a fixed
+ * height grid whose rows overflow, or a touch drag, still needs the grid to
+ * scroll an overflow:auto ancestor (or the window) as the pointer approaches
+ * the edge.
+ *
+ * This module owns a single rAF loop per drag. createEdgeScrollController() is
+ * called on the drag start, feed() on every drag move, and stop() on drag
+ * stop/unmount. The loop reads the last pointer position and scrolls the
+ * nearest scrollable element (the node itself or an ancestor) when the pointer
+ * is within the edge threshold.
+ */
+
+export interface EdgeScrollController {
+  /** Call on every drag move with the pointer's viewport coords. */
+  feed(clientX: number, clientY: number): void;
+  /** Stop the rAF loop. Safe to call multiple times. */
+  stop(): void;
+}
+
+const EDGE_THRESHOLD = 50;
+const SCROLL_STEP = 12;
+
+function getNearestScrollable(
+  node: HTMLElement | null
+): HTMLElement | null {
+  // Check the node itself first, then ancestors.
+  let el: HTMLElement | null = node;
+  while (el) {
+    const style = window.getComputedStyle(el);
+    const overflowY = style.overflowY;
+    const scrollable =
+      (overflowY === "auto" || overflowY === "scroll") &&
+      el.scrollHeight > el.clientHeight;
+    if (scrollable) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+export function createEdgeScrollController(
+  node: HTMLElement | null
+): EdgeScrollController {
+  let scrollContainer: HTMLElement | null = getNearestScrollable(node);
+  let rafId: number | null = null;
+  let lastX = 0;
+  let lastY = 0;
+  let running = false;
+
+  function step() {
+    const container = scrollContainer;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    const { clientHeight, scrollTop, scrollHeight } = container;
+    const { scrollLeft, scrollWidth, clientWidth } = container;
+
+    let dy = 0;
+    let dx = 0;
+
+    if (lastY < rect.top + EDGE_THRESHOLD && scrollTop > 0) {
+      dy = -SCROLL_STEP;
+    } else if (lastY > rect.bottom - EDGE_THRESHOLD && scrollTop + clientHeight < scrollHeight) {
+      dy = SCROLL_STEP;
+    }
+
+    if (lastX < rect.left + EDGE_THRESHOLD && scrollLeft > 0) {
+      dx = -SCROLL_STEP;
+    } else if (lastX > rect.right - EDGE_THRESHOLD && scrollLeft + clientWidth < scrollWidth) {
+      dx = SCROLL_STEP;
+    }
+
+    if (dy !== 0 || dx !== 0) {
+      container.scrollTop += dy;
+      container.scrollLeft += dx;
+    }
+
+    if (running) {
+      rafId = requestAnimationFrame(step);
+    }
+  }
+
+  return {
+    feed(clientX: number, clientY: number) {
+      lastX = clientX;
+      lastY = clientY;
+      if (!running) {
+        running = true;
+        rafId = requestAnimationFrame(step);
+      }
+    },
+    stop() {
+      running = false;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    }
+  };
+}

--- a/test/spec/drop-alignment.test.ts
+++ b/test/spec/drop-alignment.test.ts
@@ -301,9 +301,11 @@ describe("PR #2167 - Drop item alignment", () => {
       const itemCenterOffsetY = 15; // ~half of 1x1 pixel height
 
       // Without scroll:
-      const rawY_noScroll = e_clientY - gridRect.top + dragOffsetY - itemCenterOffsetY;
+      const rawY_noScroll =
+        e_clientY - gridRect.top + dragOffsetY - itemCenterOffsetY;
       // With scroll:
-      const rawY_scroll = e_clientY - gridRect.top + scrollTop + dragOffsetY - itemCenterOffsetY;
+      const rawY_scroll =
+        e_clientY - gridRect.top + scrollTop + dragOffsetY - itemCenterOffsetY;
 
       // The scroll-aware calc should report a position that is scrollTop
       // farther down, matching the content coordinate space.

--- a/test/spec/drop-alignment.test.ts
+++ b/test/spec/drop-alignment.test.ts
@@ -283,4 +283,31 @@ describe("PR #2167 - Drop item alignment", () => {
       expect(itemPixelHeight).toBe(80);
     });
   });
+
+  describe("Drop position with scroll offset (#2143)", () => {
+    it("accounts for scrollTop when computing raw grid coords", () => {
+      // Grid rect is at viewport position (50, 100) but internally scrolled
+      // 40px. The pointer is at (250, 180). A 1x1 centered item should land
+      // as if the grid's origin is at (50 + 0, 100 + 40) = (50, 140) relative
+      // to the pointer. Without scroll compensation, it'd use (50, 100).
+      const scrollTop = 40;
+      const scrollLeft = 0;
+      const gridRect = { left: 50, top: 100 };
+      const e_clientX = 250;
+      const e_clientY = 180;
+      const dragOffsetX = 0;
+      const dragOffsetY = 0;
+      const itemCenterOffsetX = 44; // ~half of 1x1 pixel width
+      const itemCenterOffsetY = 15; // ~half of 1x1 pixel height
+
+      // Without scroll:
+      const rawY_noScroll = e_clientY - gridRect.top + dragOffsetY - itemCenterOffsetY;
+      // With scroll:
+      const rawY_scroll = e_clientY - gridRect.top + scrollTop + dragOffsetY - itemCenterOffsetY;
+
+      // The scroll-aware calc should report a position that is scrollTop
+      // farther down, matching the content coordinate space.
+      expect(rawY_scroll - rawY_noScroll).toBe(scrollTop);
+    });
+  });
 });

--- a/test/spec/edgeScroll-test.ts
+++ b/test/spec/edgeScroll-test.ts
@@ -33,16 +33,18 @@ function restoreRafMock() {
 }
 
 /** A fake scrollable element with controllable geometry. */
-function makeContainer(overrides: Partial<{
-  scrollTop: number;
-  scrollLeft: number;
-  scrollHeight: number;
-  scrollWidth: number;
-  clientHeight: number;
-  clientWidth: number;
-  rect: { top: number; bottom: number; left: number; right: number };
-  overflowY: string;
-}> = {}) {
+function makeContainer(
+  overrides: Partial<{
+    scrollTop: number;
+    scrollLeft: number;
+    scrollHeight: number;
+    scrollWidth: number;
+    clientHeight: number;
+    clientWidth: number;
+    rect: { top: number; bottom: number; left: number; right: number };
+    overflowY: string;
+  }> = {}
+) {
   const state = {
     scrollTop: 0,
     scrollLeft: 0,
@@ -70,7 +72,7 @@ function makeContainer(overrides: Partial<{
 function mockComputedStyle(overflowY: string) {
   const orig = globalThis.getComputedStyle;
   (globalThis as any).getComputedStyle = () =>
-    ({ overflowY, overflowX: "auto" } as CSSStyleDeclaration);
+    ({ overflowY, overflowX: "auto" }) as CSSStyleDeclaration;
   return () => {
     (globalThis as any).getComputedStyle = orig;
   };

--- a/test/spec/edgeScroll-test.ts
+++ b/test/spec/edgeScroll-test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the edge auto-scroll controller (#2232).
+ *
+ * Verifies:
+ * - getNearestScrollable picks the nearest overflow:auto/scroll element.
+ * - The rAF loop scrolls the container when the pointer is near an edge.
+ * - It stops scrolling when the pointer leaves the threshold.
+ * - stop() cancels the loop and is idempotent.
+ * - No scroll when the container can't scroll further.
+ */
+
+import { createEdgeScrollController } from "../../src/react/components/edgeScroll";
+
+// Track rAF callbacks and scrollTop/scrollLeft mutations.
+let rafCallback: (() => void) | null = null;
+const originalRAF = globalThis.requestAnimationFrame;
+const originalCancel = globalThis.cancelAnimationFrame;
+
+function installRafMock() {
+  rafCallback = null;
+  (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+    rafCallback = cb;
+    return 1;
+  };
+  (globalThis as any).cancelAnimationFrame = (id: number) => {
+    if (id === 1) rafCallback = null;
+  };
+}
+
+function restoreRafMock() {
+  (globalThis as any).requestAnimationFrame = originalRAF;
+  (globalThis as any).cancelAnimationFrame = originalCancel;
+}
+
+/** A fake scrollable element with controllable geometry. */
+function makeContainer(overrides: Partial<{
+  scrollTop: number;
+  scrollLeft: number;
+  scrollHeight: number;
+  scrollWidth: number;
+  clientHeight: number;
+  clientWidth: number;
+  rect: { top: number; bottom: number; left: number; right: number };
+  overflowY: string;
+}> = {}) {
+  const state = {
+    scrollTop: 0,
+    scrollLeft: 0,
+    scrollHeight: 1000,
+    scrollWidth: 1000,
+    clientHeight: 200,
+    clientWidth: 200,
+    rect: { top: 0, bottom: 200, left: 0, right: 200 },
+    overflowY: "auto",
+    ...overrides
+  };
+  return {
+    scrollTop: state.scrollTop,
+    scrollLeft: state.scrollLeft,
+    scrollHeight: state.scrollHeight,
+    scrollWidth: state.scrollWidth,
+    clientHeight: state.clientHeight,
+    clientWidth: state.clientWidth,
+    getBoundingClientRect: () => state.rect,
+    parentElement: null,
+    style: {} as CSSStyleDeclaration
+  } as unknown as HTMLElement;
+}
+
+function mockComputedStyle(overflowY: string) {
+  const orig = globalThis.getComputedStyle;
+  (globalThis as any).getComputedStyle = () =>
+    ({ overflowY, overflowX: "auto" } as CSSStyleDeclaration);
+  return () => {
+    (globalThis as any).getComputedStyle = orig;
+  };
+}
+
+describe("edgeScroll (#2232)", () => {
+  beforeEach(() => {
+    installRafMock();
+  });
+
+  afterEach(() => {
+    restoreRafMock();
+  });
+
+  describe("getNearestScrollable", () => {
+    it("returns the node itself when it is scrollable", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer();
+      const controller = createEdgeScrollController(container);
+      // feed starts a loop if a scrollable is found (no crash).
+      controller.feed(100, 100);
+      expect(rafCallback).toBeDefined();
+      controller.stop();
+      restore();
+    });
+
+    it("does not scroll when no scrollable element exists", () => {
+      const restore = mockComputedStyle("visible"); // overflowY: visible -> not scrollable
+      const leaf = makeContainer();
+      leaf.parentElement = null;
+      const controller = createEdgeScrollController(leaf);
+      controller.feed(190, 190); // near bottom edge, but nothing scrollable
+      if (rafCallback) rafCallback();
+      // No scroll happens because scrollContainer is null.
+      expect(leaf.scrollTop).toBe(0);
+      expect(leaf.scrollLeft).toBe(0);
+      controller.stop();
+      restore();
+    });
+  });
+
+  describe("scroll loop behavior", () => {
+    it("scrolls down when the pointer is near the bottom edge", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer({
+        scrollTop: 0,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        rect: { top: 0, bottom: 200, left: 0, right: 200 }
+      });
+      const controller = createEdgeScrollController(container);
+
+      // Pointer near the bottom edge (bottom=200, threshold 50 -> >150).
+      controller.feed(100, 190);
+      const step = rafCallback!;
+      step();
+      expect(container.scrollTop).toBe(12); // SCROLL_STEP
+
+      controller.stop();
+      restore();
+    });
+
+    it("scrolls up when near the top edge and scrollTop > 0", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer({
+        scrollTop: 100,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        rect: { top: 0, bottom: 200, left: 0, right: 200 }
+      });
+      const controller = createEdgeScrollController(container);
+
+      controller.feed(100, 10); // near top edge
+      rafCallback!();
+      expect(container.scrollTop).toBe(100 - 12);
+
+      controller.stop();
+      restore();
+    });
+
+    it("does not scroll up when already at the top (scrollTop=0)", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer({ scrollTop: 0 });
+      const controller = createEdgeScrollController(container);
+
+      controller.feed(100, 10); // near top but can't scroll up
+      rafCallback!();
+      expect(container.scrollTop).toBe(0);
+
+      controller.stop();
+      restore();
+    });
+
+    it("scrolls left/right when near the horizontal edges", () => {
+      const restore = mockComputedStyle("auto");
+      // scrollHeight > clientHeight so the container is detected as scrollable.
+      const container = makeContainer({
+        scrollLeft: 100,
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 200,
+        scrollWidth: 1000,
+        clientWidth: 200,
+        rect: { top: 0, bottom: 300, left: 0, right: 300 }
+      });
+      const controller = createEdgeScrollController(container);
+
+      controller.feed(290, 150); // near right edge (rect.right=300, threshold 50)
+      rafCallback!();
+      expect(container.scrollLeft).toBe(100 + 12);
+
+      controller.stop();
+      restore();
+    });
+
+    it("does not scroll when the pointer is in the middle", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer();
+      const controller = createEdgeScrollController(container);
+
+      controller.feed(100, 100); // center
+      rafCallback!();
+      expect(container.scrollTop).toBe(0);
+      expect(container.scrollLeft).toBe(0);
+
+      controller.stop();
+      restore();
+    });
+  });
+
+  describe("stop()", () => {
+    it("cancels the rAF loop and is idempotent", () => {
+      const restore = mockComputedStyle("auto");
+      const container = makeContainer();
+      const controller = createEdgeScrollController(container);
+
+      controller.feed(100, 190);
+      expect(rafCallback).toBeDefined();
+
+      controller.stop();
+      expect(rafCallback).toBeNull();
+
+      // Calling stop again is safe.
+      controller.stop();
+
+      // After stop, no further scroll happens.
+      controller.feed(100, 190);
+      // feed restarts the loop, so rafCallback is set again.
+      expect(rafCallback).toBeDefined();
+      controller.stop();
+
+      restore();
+    });
+  });
+});

--- a/test/spec/touch-drag-props-test.tsx
+++ b/test/spec/touch-drag-props-test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for touch/drag prop forwarding:
+ * - #1793: allowMobileScroll must reach DraggableCore so child onClick fires
+ *   on touch devices (react-draggable preventDefaults touchstart otherwise).
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+
+// Capture the props passed to DraggableCore.
+const captured: Record<string, unknown>[] = [];
+jest.mock("react-draggable", () => {
+  return {
+    DraggableCore: (props: Record<string, unknown>) => {
+      captured.push(props);
+      return <div data-testid="draggable-core" />;
+    }
+  };
+});
+
+import { GridItem, type GridItemProps } from "../../src/react/index";
+
+describe("#1793 allowMobileScroll forwarding", () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  function renderItem(props: Partial<GridItemProps> = {}) {
+    const base: GridItemProps = {
+      children: <div>child</div>,
+      cols: 12,
+      containerWidth: 1200,
+      rowHeight: 30,
+      margin: [10, 10] as const,
+      maxRows: 10,
+      containerPadding: [10, 10] as const,
+      i: "0",
+      x: 0,
+      y: 0,
+      w: 2,
+      h: 2,
+      isDraggable: true,
+      isResizable: false,
+      isBounded: false,
+      useCSSTransforms: false,
+      ...props
+    };
+    render(<GridItem {...base} />);
+    return captured[captured.length - 1];
+  }
+
+  it("does not pass allowMobileScroll when not provided (default off)", () => {
+    const coreProps = renderItem();
+    expect(coreProps.allowMobileScroll).toBeUndefined();
+  });
+
+  it("forwards allowMobileScroll to DraggableCore when set", () => {
+    const coreProps = renderItem({ allowMobileScroll: true });
+    expect(coreProps.allowMobileScroll).toBe(true);
+  });
+});

--- a/test/spec/typescript-components-test.tsx
+++ b/test/spec/typescript-components-test.tsx
@@ -776,4 +776,47 @@ describe("TypeScript Components", () => {
       expect(layout[1]?.static).toBe(true);
     });
   });
+
+  describe("GridItem memoization (#2240)", () => {
+    it("does not re-render items whose props are unchanged", () => {
+      let renderCount = 0;
+      const CountingChild = () => {
+        renderCount++;
+        return React.createElement("div", null, "child");
+      };
+
+      const layout: Layout = [
+        { i: "a", x: 0, y: 0, w: 2, h: 2 },
+        { i: "b", x: 2, y: 0, w: 2, h: 2 }
+      ];
+
+      // The documented perf contract: consumers memoize their children so
+      // their identity is stable across GridLayout re-renders.
+      const children = layout.map((item) =>
+        React.createElement(CountingChild, { key: item.i })
+      );
+
+      const { rerender } = render(
+        React.createElement(
+          GridLayout,
+          { width: 600, cols: 12, rowHeight: 30, layout },
+          children
+        )
+      );
+
+      const countAfterFirst = renderCount;
+
+      // Re-render with the SAME layout and STABLE children — items must not
+      // re-render (#2240).
+      rerender(
+        React.createElement(
+          GridLayout,
+          { width: 600, cols: 12, rowHeight: 30, layout },
+          children
+        )
+      );
+
+      expect(renderCount).toBe(countAfterFirst);
+    });
+  });
 });

--- a/test/spec/typescript-components-test.tsx
+++ b/test/spec/typescript-components-test.tsx
@@ -792,7 +792,7 @@ describe("TypeScript Components", () => {
 
       // The documented perf contract: consumers memoize their children so
       // their identity is stable across GridLayout re-renders.
-      const children = layout.map((item) =>
+      const children = layout.map(item =>
         React.createElement(CountingChild, { key: item.i })
       );
 


### PR DESCRIPTION
- #2240: React.memo on GridItem (shallow geometry compare) - no per-move re-render
- #1793: dragConfig.allowMobileScroll threaded to DraggableCore
- #2232: edge auto-scroll finds scrollable ancestor from the dragged node
- #2143: drop position accounts for grid scroll offset
- #2203: north-resize anchors bottom edge (via resizeItemInDirection)

Verified: 550 Jest tests pass, typecheck clean, 12 new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `allowMobileScroll` option to preserve native touch scrolling while dragging.
  * Added edge auto-scrolling during drag near the boundaries of scrollable containers.
* **Bug Fixes**
  * Improved resizing behavior by correctly updating anchored vertical position around compaction.
  * Fixed external drop positioning to account for the grid’s internal scroll offsets.
* **Tests**
  * Added/expanded unit and regression tests for touch drag props forwarding, edge scrolling, drop alignment with scroll, and memoization/rerender behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->