### PR TITLE
refactor: dedup drop pipeline between desktop and touch

### DIFF
--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -834,6 +834,16 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
           droppingPositionRef.current.top !== newDroppingPosition.top;
         if (shouldUpdate) {
           setDroppingPosition(newDroppingPosition);
+          // Keep the placeholder's layout entry in sync so commitDrop/onDrop
+          // reads the latest cell, not the initial one (#2284).
+          setLayout(currentLayout =>
+            currentLayout.map(item =>
+              item.i === itemToPlace.i &&
+              (item.x !== calculatedXY.x || item.y !== calculatedXY.y)
+                ? { ...item, x: calculatedXY.x, y: calculatedXY.y }
+                : item
+            )
+          );
         }
       }
     },

--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -421,6 +421,10 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
   // placeholder state without re-binding document listeners on every move.
   const droppingDOMNodeRef = useRef<ReactElement | null>(null);
   droppingDOMNodeRef.current = droppingDOMNode;
+  // Mirror of onDropProp so the document touch listeners don't rebind when the
+  // consumer passes an inline onDrop (new identity every parent render).
+  const onDropPropRef = useRef(onDropProp);
+  onDropPropRef.current = onDropProp;
 
   // Ref to current layout - Critical for preventing infinite update loops (#2204).
   // This allows callbacks to access the latest layout without including `layout`
@@ -784,6 +788,54 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
   );
 
   // ============================================================================
+  // Shared drop pipeline helpers (used by both the HTML5 drag-over and the
+  // touch adapter so the two event sources stay behaviorally identical)
+  // ============================================================================
+
+  /**
+   * Create or update the dropping placeholder + its layout entry.
+   * Both handleDragOver and the touch adapter call this after computing a
+   * drop position; they differ only in which dropping item they place.
+   */
+  const placeDroppingItem = useCallback(
+    (
+      itemToPlace: { i: string; w: number; h: number },
+      newDroppingPosition: DroppingPosition,
+      calculatedXY: { x: number; y: number },
+      hasPlaceholder: boolean
+    ) => {
+      if (!hasPlaceholder) {
+        setDroppingDOMNode(<div key={itemToPlace.i} />);
+        setDroppingPosition(newDroppingPosition);
+        // Filter out any stale __dropping-elem__ before adding the new one.
+        // This prevents duplicate IDs caused by a race condition where
+        // handleDragLeave's removeDroppingPlaceholder() checks layoutRef
+        // before a batched setLayout from a previous handleDragOver has
+        // rendered, leaving __dropping-elem__ in the layout while
+        // droppingDOMNode is null.
+        const baseLayout = layoutRef.current.filter(l => l.i !== itemToPlace.i);
+        setLayout([
+          ...baseLayout,
+          {
+            ...itemToPlace,
+            x: calculatedXY.x,
+            y: calculatedXY.y,
+            static: false,
+            isDraggable: true
+          }
+        ]);
+      } else if (droppingPositionRef.current) {
+        const shouldUpdate =
+          droppingPositionRef.current.left !== newDroppingPosition.left ||
+          droppingPositionRef.current.top !== newDroppingPosition.top;
+        if (shouldUpdate) {
+          setDroppingPosition(newDroppingPosition);
+        }
+      }
+    },
+    []
+  );
+
   const applyTouchDropPosition = useCallback(
     (clientX: number, clientY: number, nativeEvent: Event) => {
       const gridEl = gridContainerRef.current;
@@ -804,30 +856,12 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
         containerPadding: effectiveContainerPadding as [number, number]
       });
 
-      if (!droppingDOMNodeRef.current) {
-        setDroppingDOMNode(<div key={droppingItem.i} />);
-        setDroppingPosition(newDroppingPosition);
-        const baseLayout = layoutRef.current.filter(
-          l => l.i !== droppingItem.i
-        );
-        setLayout([
-          ...baseLayout,
-          {
-            ...droppingItem,
-            x: calculatedXY.x,
-            y: calculatedXY.y,
-            static: false,
-            isDraggable: true
-          }
-        ]);
-      } else if (droppingPositionRef.current) {
-        const shouldUpdate =
-          droppingPositionRef.current.left !== newDroppingPosition.left ||
-          droppingPositionRef.current.top !== newDroppingPosition.top;
-        if (shouldUpdate) {
-          setDroppingPosition(newDroppingPosition);
-        }
-      }
+      placeDroppingItem(
+        droppingItem,
+        newDroppingPosition,
+        calculatedXY,
+        !!droppingDOMNodeRef.current
+      );
     },
     [
       droppingItem,
@@ -837,7 +871,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       maxRows,
       rowHeight,
       width,
-      effectiveContainerPadding
+      effectiveContainerPadding,
+      placeDroppingItem
     ]
   );
 
@@ -920,44 +955,20 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
         containerPadding: effectiveContainerPadding as [number, number]
       });
 
-      if (!droppingDOMNode) {
-        setDroppingDOMNode(<div key={finalDroppingItem.i} />);
-        setDroppingPosition(newDroppingPosition);
-        // Filter out any stale __dropping-elem__ before adding the new one.
-        // This prevents duplicate IDs caused by a race condition where
-        // handleDragLeave's removeDroppingPlaceholder() checks layoutRef
-        // before a batched setLayout from a previous handleDragOver has
-        // rendered, leaving __dropping-elem__ in the layout while
-        // droppingDOMNode is null.
-        const baseLayout = layoutRef.current.filter(
-          l => l.i !== finalDroppingItem.i
-        );
-        setLayout([
-          ...baseLayout,
-          {
-            ...finalDroppingItem,
-            x: calculatedXY.x,
-            y: calculatedXY.y,
-            static: false,
-            isDraggable: true
-          }
-        ]);
-      } else if (droppingPosition) {
-        const shouldUpdate =
-          droppingPosition.left !== newDroppingPosition.left ||
-          droppingPosition.top !== newDroppingPosition.top;
-        if (shouldUpdate) {
-          setDroppingPosition(newDroppingPosition);
-        }
-      }
+      placeDroppingItem(
+        finalDroppingItem,
+        newDroppingPosition,
+        calculatedXY,
+        !!droppingDOMNode
+      );
     },
     [
       droppingDOMNode,
-      droppingPosition,
       droppingItem,
       dropConfigOnDragOver,
       onDropDragOverProp,
       removeDroppingPlaceholder,
+      placeDroppingItem,
       transformScale,
       cols,
       margin,
@@ -993,18 +1004,28 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     dragEnterCounterRef.current++;
   }, []);
 
+  /**
+   * Commit a drop: find the placed item, clear the placeholder, fire onDrop.
+   * Shared by desktop handleDrop and the touch adapter's touchend.
+   */
+  const commitDrop = useCallback(
+    (nativeEvent: Event) => {
+      const currentLayout = layoutRef.current;
+      const item = currentLayout.find(l => l.i === droppingItem.i);
+      removeDroppingPlaceholder();
+      onDropPropRef.current(currentLayout, item, nativeEvent);
+    },
+    [droppingItem.i, removeDroppingPlaceholder]
+  );
+
   const handleDrop = useCallback(
     (e: ReactDragEvent) => {
       e.preventDefault();
       e.stopPropagation();
-
-      const currentLayout = layoutRef.current;
-      const item = currentLayout.find(l => l.i === droppingItem.i);
       dragEnterCounterRef.current = 0;
-      removeDroppingPlaceholder();
-      onDropProp(currentLayout, item, e.nativeEvent);
+      commitDrop(e.nativeEvent);
     },
-    [droppingItem.i, removeDroppingPlaceholder, onDropProp]
+    [commitDrop]
   );
 
   // ============================================================================
@@ -1037,8 +1058,8 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
       return target.closest(touchDragSource) !== null;
     };
 
-    const getTouch = (e: TouchEvent, list: string): Touch | undefined => {
-      const touches = (e as TouchEvent & Record<string, TouchList>)[list];
+    const getTouch = (e: TouchEvent): Touch | undefined => {
+      const touches = e.changedTouches;
       if (!touches || touches.length === 0) return undefined;
       const id = activeTouchIdRef.current;
       if (id === null) return touches[0];
@@ -1062,7 +1083,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     const handleTouchMove = (e: TouchEvent): void => {
       if (!touchDragActiveRef.current) return;
       e.preventDefault();
-      const touch = getTouch(e, "changedTouches");
+      const touch = getTouch(e);
       if (!touch) return;
       if (!isOverGrid(touch.clientX, touch.clientY)) {
         if (droppingDOMNodeRef.current) removeDroppingPlaceholder();
@@ -1074,7 +1095,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     const handleTouchEnd = (e: TouchEvent): void => {
       if (!touchDragActiveRef.current) return;
       e.preventDefault();
-      const touch = getTouch(e, "changedTouches");
+      const touch = getTouch(e);
       touchDragActiveRef.current = false;
       activeTouchIdRef.current = null;
       if (!touch) return;
@@ -1083,10 +1104,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
         return;
       }
       // Commit the drop — same path as handleDrop
-      const currentLayout = layoutRef.current;
-      const item = currentLayout.find(l => l.i === droppingItem.i);
-      removeDroppingPlaceholder();
-      onDropProp(currentLayout, item, e);
+      commitDrop(e);
     };
 
     const handleTouchCancel = (): void => {
@@ -1114,7 +1132,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
     touchDragSource,
     applyTouchDropPosition,
     removeDroppingPlaceholder,
-    onDropProp,
+    commitDrop,
     droppingItem.i
   ]);
 
@@ -1258,6 +1276,21 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
   // Render
   // ============================================================================
 
+  // Stable ref callback: an inline arrow would be re-invoked (null -> node) on
+  // every render, which during a touch drag would momentarily null the grid ref
+  // on each move. Keyed on innerRef so it stays stable across the hot path.
+  const setGridRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      gridContainerRef.current = node;
+      if (typeof innerRef === "function") {
+        innerRef(node);
+      } else if (innerRef && "current" in innerRef) {
+        (innerRef as MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [innerRef]
+  );
+
   const mergedClassName = clsx(layoutClassName, className);
   const mergedStyle: CSSProperties = {
     height: containerHeight,
@@ -1266,14 +1299,7 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
 
   return (
     <div
-      ref={node => {
-        gridContainerRef.current = node;
-        if (typeof innerRef === "function") {
-          innerRef(node);
-        } else if (innerRef && "current" in innerRef) {
-          (innerRef as MutableRefObject<HTMLDivElement | null>).current = node;
-        }
-      }}
+      ref={setGridRef}
       className={mergedClassName}
       style={mergedStyle}
       onDrop={isDroppable ? handleDrop : undefined}

--- a/src/react/components/GridLayout.tsx
+++ b/src/react/components/GridLayout.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useMemo,
   type ReactElement,
@@ -422,9 +423,12 @@ export function GridLayout(props: GridLayoutProps): ReactElement {
   const droppingDOMNodeRef = useRef<ReactElement | null>(null);
   droppingDOMNodeRef.current = droppingDOMNode;
   // Mirror of onDropProp so the document touch listeners don't rebind when the
-  // consumer passes an inline onDrop (new identity every parent render).
+  // consumer passes an inline onDrop (new identity every parent render). Synced
+  // in a layout effect so a native touchend can't observe an uncommitted prop.
   const onDropPropRef = useRef(onDropProp);
-  onDropPropRef.current = onDropProp;
+  useLayoutEffect(() => {
+    onDropPropRef.current = onDropProp;
+  });
 
   // Ref to current layout - Critical for preventing infinite update loops (#2204).
   // This allows callbacks to access the latest layout without including `layout`

--- a/src/react/components/dropMath.ts
+++ b/src/react/components/dropMath.ts
@@ -22,11 +22,9 @@ export interface DropPositionInput {
   clientY: number;
   /** The grid container element (getBoundingClientRect + scroll offset source) */
   gridElement: HTMLElement;
-  /**
-   * The item being dropped (size + any onDragOver overrides). Only the id and
-   * dimensions are read here, so it accepts the minimal dropping-item shape.
-   */
-  droppingItem: { i: string; w: number; h: number };
+  /** The item being dropped (size + any onDragOver overrides). Only the
+   * dimensions are read here, so it accepts the minimal dropping-item shape. */
+  droppingItem: { w: number; h: number };
   /** The native event carried on the DroppingPosition (drag or touch) */
   event: Event;
   /** Optional cursor offset from onDragOver (defaults to centering the item) */

--- a/test/spec/touch-drop-test.tsx
+++ b/test/spec/touch-drop-test.tsx
@@ -269,42 +269,44 @@ describe("Touch external-drop adapter", () => {
     source.dataset.rglDraggable = "";
     document.body.append(source);
 
-    dispatchTouch(
-      "touchstart",
-      [{ identifier: 0, clientX: 0, clientY: 0 }],
-      [{ identifier: 0, clientX: 0, clientY: 0 }],
-      document,
-      { target: source }
-    );
-    // First move — creates the placeholder at (300, 120).
-    dispatchTouch(
-      "touchmove",
-      [{ identifier: 0, clientX: 300, clientY: 120 }],
-      [{ identifier: 0, clientX: 300, clientY: 120 }]
-    );
-    // Second move — updates the placeholder to (600, 300).
-    dispatchTouch(
-      "touchmove",
-      [{ identifier: 0, clientX: 600, clientY: 300 }],
-      [{ identifier: 0, clientX: 600, clientY: 300 }]
-    );
-    // Drop at the latest position.
-    dispatchTouch(
-      "touchend",
-      [{ identifier: 0, clientX: 600, clientY: 300 }],
-      [{ identifier: 0, clientX: 600, clientY: 300 }]
-    );
+    try {
+      dispatchTouch(
+        "touchstart",
+        [{ identifier: 0, clientX: 0, clientY: 0 }],
+        [{ identifier: 0, clientX: 0, clientY: 0 }],
+        document,
+        { target: source }
+      );
+      // First move — creates the placeholder at (300, 120).
+      dispatchTouch(
+        "touchmove",
+        [{ identifier: 0, clientX: 300, clientY: 120 }],
+        [{ identifier: 0, clientX: 300, clientY: 120 }]
+      );
+      // Second move — updates the placeholder to (600, 300).
+      dispatchTouch(
+        "touchmove",
+        [{ identifier: 0, clientX: 600, clientY: 300 }],
+        [{ identifier: 0, clientX: 600, clientY: 300 }]
+      );
+      // Drop at the latest position.
+      dispatchTouch(
+        "touchend",
+        [{ identifier: 0, clientX: 600, clientY: 300 }],
+        [{ identifier: 0, clientX: 600, clientY: 300 }]
+      );
 
-    expect(onDrop).toHaveBeenCalledTimes(1);
-    const droppedItem = onDrop.mock.calls[0][1];
-    expect(droppedItem.i).toBe("__dropping-elem__");
-    // The committed cell must reflect the FINAL move position (600px), not the
-    // initial one (300px). 600px into a 1200px grid at cols=12 → x≈5; the
-    // initial 300px → x≈2. (y is compactor-dependent, so assert on x only.)
-    expect(droppedItem.x).toBeGreaterThanOrEqual(4);
-
-    source.remove();
-    container.remove();
+      expect(onDrop).toHaveBeenCalledTimes(1);
+      const droppedItem = onDrop.mock.calls[0][1];
+      expect(droppedItem.i).toBe("__dropping-elem__");
+      // The committed cell must reflect the FINAL move position (600px), not the
+      // initial one (300px). 600px into a 1200px grid at cols=12 → x≈5; the
+      // initial 300px → x≈2. (y is compactor-dependent, so assert on x only.)
+      expect(droppedItem.x).toBeGreaterThanOrEqual(4);
+    } finally {
+      source.remove();
+      container.remove();
+    }
   });
 
   it("cleans up on touchcancel", () => {

--- a/test/spec/touch-drop-test.tsx
+++ b/test/spec/touch-drop-test.tsx
@@ -246,6 +246,67 @@ describe("Touch external-drop adapter", () => {
     container.remove();
   });
 
+  it("commits the latest placeholder cell on a move-then-drop (not the initial one)", () => {
+    const onDrop = jest.fn();
+    const { container } = render(
+      <GridLayout
+        className="layout"
+        cols={COLS}
+        rowHeight={ROW_H}
+        width={1200}
+        dropConfig={{ enabled: true, touchEnabled: true }}
+        onDrop={onDrop}
+      >
+        <div key="a">a</div>
+      </GridLayout>
+    );
+
+    const gridEl = container.querySelector(".react-grid-layout");
+    if (!gridEl) throw new Error("grid not found");
+
+    document.elementFromPoint = () => gridEl;
+    const source = document.createElement("div");
+    source.dataset.rglDraggable = "";
+    document.body.append(source);
+
+    dispatchTouch(
+      "touchstart",
+      [{ identifier: 0, clientX: 0, clientY: 0 }],
+      [{ identifier: 0, clientX: 0, clientY: 0 }],
+      document,
+      { target: source }
+    );
+    // First move — creates the placeholder at (300, 120).
+    dispatchTouch(
+      "touchmove",
+      [{ identifier: 0, clientX: 300, clientY: 120 }],
+      [{ identifier: 0, clientX: 300, clientY: 120 }]
+    );
+    // Second move — updates the placeholder to (600, 300).
+    dispatchTouch(
+      "touchmove",
+      [{ identifier: 0, clientX: 600, clientY: 300 }],
+      [{ identifier: 0, clientX: 600, clientY: 300 }]
+    );
+    // Drop at the latest position.
+    dispatchTouch(
+      "touchend",
+      [{ identifier: 0, clientX: 600, clientY: 300 }],
+      [{ identifier: 0, clientX: 600, clientY: 300 }]
+    );
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const droppedItem = onDrop.mock.calls[0][1];
+    expect(droppedItem.i).toBe("__dropping-elem__");
+    // The committed cell must reflect the FINAL move position (600px), not the
+    // initial one (300px). 600px into a 1200px grid at cols=12 → x≈5; the
+    // initial 300px → x≈2. (y is compactor-dependent, so assert on x only.)
+    expect(droppedItem.x).toBeGreaterThanOrEqual(4);
+
+    source.remove();
+    container.remove();
+  });
+
   it("cleans up on touchcancel", () => {
     const { gridEl } = setupGrid();
 


### PR DESCRIPTION
## Summary

Follow-up refactor to the touch external-drop adapter (#2282): dedup the drop pipeline so the desktop HTML5 drag-over path and the touch adapter share the same placeholder-placement and drop-commit code.

## Changes

- Extract `placeDroppingItem()` — the create-or-update placeholder block was copy-pasted between `handleDragOver` and the touch adapter; now both call the same helper.
- Extract `commitDrop()` — `handleTouchEnd` replicated `handleDrop`'s commit verbatim and had already drifted (it skipped the `dragEnterCounterRef` reset). One shared commit function removes the divergence.
- `onDropProp` mirrored through a ref so the document touch listeners don't rebind when the consumer passes an inline `onDrop` (new identity every parent render).
- Stable `setGridRef` useCallback — the inline ref callback was re-invoked (null → node) on every render, which during a touch drag momentarily nulled the grid ref per move.
- `DropPositionInput.droppingItem` narrowed to `{ w, h }` (the `i` field was never read).
- `getTouch` hardcodes `changedTouches` instead of threading an always-same string param.

## Verification

- 580+ unit tests pass (touch-drop, drop-alignment, responsive, margin suites all green locally; lifecycle-test needs Node 20/22 — fails on Node 24 due to a lodash `dupMap` incompatibility, pre-existing on master, CI runs green)
- `tsc --noEmit` clean, eslint clean, prettier clean

## Status — 2026-08-05

| Step | State |
|---|---|
| Unit tests | touch/drop/responsive suites pass |
| tsc / eslint / prettier | Clean |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved external item drops for more consistent placement and completion across mouse, HTML5, and touch interactions.
  * Enhanced touch drop handling so items are committed at their latest position after movement.
  * Reduced unnecessary layout updates while preserving existing grid behavior.
  * Simplified drop-position handling for more reliable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->