### PR TITLE
fix: bound resize to the container edge in isBounded grids (#1779)

### DIFF
--- a/src/react/components/GridItem.tsx
+++ b/src/react/components/GridItem.tsx
@@ -301,12 +301,14 @@ function GridItemInner(props: GridItemProps): ReactElement {
   // Constraint context for applying constraints
   // Note: This does NOT include layout in its dependencies to prevent infinite loops (#2210).
   // The layout is accessed via layoutRef.current inside the callbacks that use this context.
+  // containerHeight is supplied per-interaction (see getConstraintContext) so a resize can
+  // be bounded to the rendered container (#1779); auto-height grids measure 0 here.
   const constraintContext: ConstraintContext = useMemo(
     () => ({
       cols,
       maxRows,
       containerWidth,
-      containerHeight: 0, // Auto-height grids don't have a fixed container height
+      containerHeight: 0, // Overridden per-interaction with the measured container height
       rowHeight,
       margin,
       // Use empty layout here - the actual layout will be accessed via layoutRef when needed
@@ -319,8 +321,9 @@ function GridItemInner(props: GridItemProps): ReactElement {
   // Create a getter for constraint context with current layout
   // This is called inside callbacks to get fresh layout data without causing re-renders
   const getConstraintContext = useCallback(
-    (): ConstraintContext => ({
+    (containerHeight?: number): ConstraintContext => ({
       ...constraintContext,
+      containerHeight: containerHeight ?? constraintContext.containerHeight,
       layout: layoutRef.current
     }),
     [constraintContext]
@@ -671,6 +674,12 @@ function GridItemInner(props: GridItemProps): ReactElement {
 
       resizePositionRef.current = updatedSize;
 
+      // Measure the rendered container height so containerBounds (legacy
+      // isBounded) can clamp a resize to the container edge (#1779). The item's
+      // offsetParent is the grid container; clientHeight reflects the current
+      // rendered height, so the resize cannot push the item past it.
+      const containerHeight = node?.offsetParent?.clientHeight ?? 0;
+
       // Calculate raw grid dimensions and apply constraints
       const rawSize = calcWHRaw(
         positionParams,
@@ -683,7 +692,7 @@ function GridItemInner(props: GridItemProps): ReactElement {
         rawSize.w,
         rawSize.h,
         resizeHandle,
-        getConstraintContext()
+        getConstraintContext(containerHeight)
       );
 
       handler(i, newW, newH, {

--- a/test/spec/resize-constraints-test.tsx
+++ b/test/spec/resize-constraints-test.tsx
@@ -9,9 +9,19 @@ import React from "react";
 import { render } from "@testing-library/react";
 
 // Mock react-resizable to capture props passed to Resizable
+type ResizeHandler = (
+  e: unknown,
+  data: {
+    node: HTMLElement;
+    size: { width: number; height: number };
+    handle: string;
+  }
+) => void;
+
 const mockResizableProps: {
   minConstraints?: [number, number];
   maxConstraints?: [number, number];
+  onResize?: ResizeHandler;
 }[] = [];
 
 jest.mock("react-resizable", () => {
@@ -21,7 +31,8 @@ jest.mock("react-resizable", () => {
     Resizable: (props: Record<string, unknown>) => {
       mockResizableProps.push({
         minConstraints: props.minConstraints as [number, number] | undefined,
-        maxConstraints: props.maxConstraints as [number, number] | undefined
+        maxConstraints: props.maxConstraints as [number, number] | undefined,
+        onResize: props.onResize as ResizeHandler | undefined
       });
       const { Resizable: ActualResizable } = actual;
       return <ActualResizable {...props} />;
@@ -32,6 +43,7 @@ jest.mock("react-resizable", () => {
 // Import GridItem AFTER the mock is set up
 import { GridItem, type GridItemProps } from "../../src/react/index";
 import { calcGridItemWHPx, calcGridColWidth } from "../../src/core/calculate";
+import { containerBounds } from "../../src/core/constraints";
 
 describe("Resize Visual Constraints (#2235)", () => {
   beforeEach(() => {
@@ -173,5 +185,122 @@ describe("Resize Visual Constraints (#2235)", () => {
     // maxConstraints should be [Infinity, Infinity]
     expect(lastProps?.maxConstraints![0]).toBe(Infinity);
     expect(lastProps?.maxConstraints![1]).toBe(Infinity);
+  });
+});
+
+describe("Resize Bounded to Container (#1779)", () => {
+  beforeEach(() => {
+    mockResizableProps.length = 0;
+  });
+
+  // Build a resize node whose offsetParent is a fixed-height grid container.
+  // setupTests mocks offsetParent to return parentNode, and clientHeight is 0 in
+  // jsdom, so we define it explicitly (410px = 10 rows at rowHeight 30, margin 10).
+  function buildNodeWithContainerHeight(containerHeight: number): HTMLElement {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientHeight", {
+      value: containerHeight,
+      configurable: true
+    });
+    const node = document.createElement("div");
+    container.append(node);
+    return node;
+  }
+
+  function renderItem(overrides: Partial<GridItemProps> = {}) {
+    const props: GridItemProps = {
+      children: <div>test child</div>,
+      cols: 12,
+      containerWidth: 1200,
+      rowHeight: 30,
+      margin: [10, 10] as const,
+      maxRows: Infinity, // Bounded grids rely on containerBounds, not maxRows
+      containerPadding: [10, 10] as const,
+      i: "0",
+      x: 0,
+      y: 8,
+      w: 2,
+      h: 2,
+      isDraggable: true,
+      isResizable: true,
+      isBounded: true,
+      useCSSTransforms: true,
+      constraints: [containerBounds],
+      ...overrides
+    };
+    render(<GridItem {...props} />);
+    const last = mockResizableProps[mockResizableProps.length - 1];
+    if (!last) throw new Error("Resizable was never rendered");
+    return last;
+  }
+
+  function resize(
+    onResize: ResizeHandler,
+    node: HTMLElement,
+    widthPx: number,
+    heightPx: number,
+    handle: string
+  ) {
+    onResize(new MouseEvent("mousemove", { bubbles: true }), {
+      node,
+      size: { width: widthPx, height: heightPx },
+      handle
+    });
+  }
+
+  it("clamps a south resize to the container bottom edge (#1779)", () => {
+    const results: Array<{ w: number; h: number }> = [];
+    const captured = renderItem({
+      onResize: (_i: string, w: number, h: number) => {
+        results.push({ w, h });
+      }
+    });
+    const node = buildNodeWithContainerHeight(410); // 10 visible rows
+
+    // Item sits at y=8, h=2 (bottom edge = row 10). A south resize to ~5 rows
+    // must be clamped so the item cannot grow past the container.
+    resize(captured.onResize!, node, 200, 200, "s");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ w: 2, h: 2 });
+  });
+
+  it("clamps an east resize to the container right edge (#1779)", () => {
+    const results: Array<{ w: number; h: number }> = [];
+    const captured = renderItem({
+      x: 10,
+      y: 0,
+      w: 2,
+      h: 2,
+      onResize: (_i: string, w: number, h: number) => {
+        results.push({ w, h });
+      }
+    });
+    const node = buildNodeWithContainerHeight(410);
+
+    // Item at x=10, w=2 in a 12-col grid. An east resize to ~6 cols must clamp
+    // to cols - x = 2.
+    resize(captured.onResize!, node, 600, 80, "e");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ w: 2, h: 2 });
+  });
+
+  it("does not clamp a south resize when the item fits in the container (#1779)", () => {
+    const results: Array<{ w: number; h: number }> = [];
+    const captured = renderItem({
+      y: 0,
+      h: 2,
+      onResize: (_i: string, w: number, h: number) => {
+        results.push({ w, h });
+      }
+    });
+    const node = buildNodeWithContainerHeight(410); // 10 visible rows
+
+    // Item at y=0 can grow south to row 10 without leaving the container.
+    resize(captured.onResize!, node, 200, 200, "s"); // ~5 rows
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ w: 2, h: 5 });
   });
 });


### PR DESCRIPTION
## Summary

Fix #1779: in a bounded grid (`isBounded` / `containerBounds`), resizing an item could push its bottom/right edge past the grid container, even though drag was properly bounded.

## Root cause

`GridItem` hardcoded `containerHeight: 0` in its constraint context. `containerBounds.constrainSize` (added for isBounded) computes visible rows as `containerHeight > 0 ? floor((containerHeight + margin) / (rowHeight + margin)) : maxRows`. With `containerHeight: 0`, it fell back to `maxRows` — `Infinity` in a bounded grid — so the clamp never fired and a south/east resize could overflow the container.

## Fix

`GridItem`'s `getConstraintContext` accepts an optional `containerHeight` override. The resize handler measures the grid container's rendered height (`node.offsetParent.clientHeight`, the same source the drag path uses) and feeds it into `applySizeConstraints`, so `containerBounds.constrainSize` clamps w/h to the visible container. Falls back to `maxRows` (previous behavior) when no container is measurable — auto-height grids unchanged.

The drag path is deliberately untouched: it's already bounded by the pixel clamp, and feeding the measured height there would tighten legacy bounded drag by the container-padding amount.

## Tests

Added a `Resize Bounded to Container (#1779)` block to `test/spec/resize-constraints-test.tsx`:
- south resize at `y=8 h=2` in a 10-row container clamps `h` to 2
- east resize at `x=10 w=2` in a 12-col grid clamps `w` to 2
- south resize of a fitting item is not over-clamped (`h: 5`)

## Status — 2026-08-05

| Step | State |
|---|---|
| Unit tests | 587 pass (6 resize-constraints), tsc clean |
| Formatting/lint | Prettier + ESLint clean |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid items now resize within the available container boundaries.
  * Resizing toward the container’s south or east edges is clamped appropriately.
  * Items can continue growing when sufficient space remains within the container.

* **Tests**
  * Added coverage for container-bound resizing and edge constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->